### PR TITLE
STITCH-1016 - Fix broken email registration endpoint

### DIFF
--- a/StitchCore/StitchCore/Source/Core/StitchClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchClient.swift
@@ -54,7 +54,7 @@ public class StitchClient: StitchClientType {
 
         lazy var localUserpassResetRoute = "\(authProvidersExtensionRoute)/local-userpass/reset"
         lazy var localUserpassResetSendRoute = "\(authProvidersExtensionRoute)/local-userpass/reset/send"
-        lazy var localUserpassRegisterRoute = "\(authProvidersExtensionRoute)/local-userpass/register/"
+        lazy var localUserpassRegisterRoute = "\(authProvidersExtensionRoute)/local-userpass/register"
         lazy var localUserpassConfirmRoute = "\(authProvidersExtensionRoute)/local-userpass/confirm"
         lazy var localUserpassConfirmSendRoute = "\(authProvidersExtensionRoute)/local-userpass/confirm/send"
 


### PR DESCRIPTION
`register` on the the `StitchClient` currently returns a 404, removing the trailing slash in the URL seems to fix it.