### PR TITLE
STITCH-1040 Improve semantics of multiple logins

### DIFF
--- a/StitchCore/StitchCore/Source/Auth/AuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/AuthProvider.swift
@@ -7,7 +7,7 @@ import ExtendedJson
  */
 public protocol AuthProvider {
     /// The authentication type of this provider.
-    var type: String {get}
+    var type: AuthProviderTypes {get}
 
     /// The JSON payload containing authentication material.
     var payload: Document {get}

--- a/StitchCore/StitchCore/Source/Auth/AuthProviderInfo.swift
+++ b/StitchCore/StitchCore/Source/Auth/AuthProviderInfo.swift
@@ -80,7 +80,7 @@ public struct CustomAuthProviderInfo: AuthProviderType {
     }
 }
 
-private enum AuthProviderTypes: String {
+internal enum AuthProviderTypes: String {
     case google = "oauth2-google"
     case facebook = "oauth2-facebook"
     case apiKey = "api-key"

--- a/StitchCore/StitchCore/Source/Auth/AuthProviderInfo.swift
+++ b/StitchCore/StitchCore/Source/Auth/AuthProviderInfo.swift
@@ -80,7 +80,7 @@ public struct CustomAuthProviderInfo: AuthProviderType {
     }
 }
 
-internal enum AuthProviderTypes: String {
+public enum AuthProviderTypes: String {
     case google = "oauth2-google"
     case facebook = "oauth2-facebook"
     case apiKey = "api-key"

--- a/StitchCore/StitchCore/Source/Auth/Providers/Anonymous/AnonymousAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/Anonymous/AnonymousAuthProvider.swift
@@ -3,7 +3,7 @@ import ExtendedJson
 /// AnonymousAuthProvider provides a way to authenticate anonymously.
 public struct AnonymousAuthProvider: AuthProvider {
     /// The authentication type for anonymous login.
-    public let type: String = AuthProviderTypes.anonymous.rawValue
+    public let type: AuthProviderTypes = AuthProviderTypes.anonymous
     
     /// The JSON payload containing authentication material.
     public var payload: Document = [:]

--- a/StitchCore/StitchCore/Source/Auth/Providers/Anonymous/AnonymousAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/Anonymous/AnonymousAuthProvider.swift
@@ -3,7 +3,7 @@ import ExtendedJson
 /// AnonymousAuthProvider provides a way to authenticate anonymously.
 public struct AnonymousAuthProvider: AuthProvider {
     /// The authentication type for anonymous login.
-    public let type: String = "anon-user"
+    public let type: String = AuthProviderTypes.anonymous.rawValue
     
     /// The JSON payload containing authentication material.
     public var payload: Document = [:]

--- a/StitchCore/StitchCore/Source/Auth/Providers/ApiKey/ApiKeyAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/ApiKey/ApiKeyAuthProvider.swift
@@ -12,7 +12,7 @@ import ExtendedJson
 public struct ApiKeyAuthProvider: AuthProvider {
     private let key: String
 
-    public var type: String = "api-key"
+    public var type: String = AuthProviderTypes.apiKey.rawValue
     public var name: String = "api-key"
 
     public var payload: Document {

--- a/StitchCore/StitchCore/Source/Auth/Providers/ApiKey/ApiKeyAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/ApiKey/ApiKeyAuthProvider.swift
@@ -12,7 +12,7 @@ import ExtendedJson
 public struct ApiKeyAuthProvider: AuthProvider {
     private let key: String
 
-    public var type: String = AuthProviderTypes.apiKey.rawValue
+    public var type: AuthProviderTypes = AuthProviderTypes.apiKey
     public var name: String = "api-key"
 
     public var payload: Document {

--- a/StitchCore/StitchCore/Source/Auth/Providers/Custom/CustomAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/Custom/CustomAuthProvider.swift
@@ -4,7 +4,7 @@ import ExtendedJson
 // CustomAuthProvider is a special case that does not
 // follow previous protocols.
 public struct CustomAuthProvider: AuthProvider {
-    public var type: String = AuthProviderTypes.custom.rawValue
+    public var type: AuthProviderTypes = AuthProviderTypes.custom
 
     public var payload: Document { return ["token": jwt] }
 

--- a/StitchCore/StitchCore/Source/Auth/Providers/Custom/CustomAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/Custom/CustomAuthProvider.swift
@@ -4,7 +4,7 @@ import ExtendedJson
 // CustomAuthProvider is a special case that does not
 // follow previous protocols.
 public struct CustomAuthProvider: AuthProvider {
-    public var type: String = "custom-token"
+    public var type: String = AuthProviderTypes.custom.rawValue
 
     public var payload: Document { return ["token": jwt] }
 

--- a/StitchCore/StitchCore/Source/Auth/Providers/EmailPassword/EmailPasswordAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/EmailPassword/EmailPasswordAuthProvider.swift
@@ -4,9 +4,7 @@ import ExtendedJson
 /// EmailPasswordAuthProvider provides a way to authenticate using an email and password.
 public struct EmailPasswordAuthProvider: AuthProvider {
     /// The authentication type for email/pass login.
-    public var type: String {
-        return AuthProviderTypes.emailPass.rawValue
-    }
+    public var type: AuthProviderTypes = AuthProviderTypes.emailPass
 
     /// The JSON payload containing the username and password.
     public var payload: Document {

--- a/StitchCore/StitchCore/Source/Auth/Providers/EmailPassword/EmailPasswordAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/EmailPassword/EmailPasswordAuthProvider.swift
@@ -5,7 +5,7 @@ import ExtendedJson
 public struct EmailPasswordAuthProvider: AuthProvider {
     /// The authentication type for email/pass login.
     public var type: String {
-        return "local-userpass"
+        return AuthProviderTypes.emailPass.rawValue
     }
 
     /// The JSON payload containing the username and password.

--- a/StitchCore/StitchCore/Source/Auth/Providers/Facebook/FacebookAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/Facebook/FacebookAuthProvider.swift
@@ -5,7 +5,7 @@ import ExtendedJson
 public struct FacebookAuthProvider: AuthProvider {
     /// The authentication type for facebook login.
     public var type: String {
-        return "oauth2-facebook"
+        return AuthProviderTypes.facebook.rawValue
     }
 
     /// The JSON payload containing the accessToken.

--- a/StitchCore/StitchCore/Source/Auth/Providers/Facebook/FacebookAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/Facebook/FacebookAuthProvider.swift
@@ -4,9 +4,7 @@ import ExtendedJson
 /// FacebookAuthProvider provides a way to authenticate via Facebook's OAuth 2.0 provider.
 public struct FacebookAuthProvider: AuthProvider {
     /// The authentication type for facebook login.
-    public var type: String {
-        return AuthProviderTypes.facebook.rawValue
-    }
+    public var type: AuthProviderTypes = AuthProviderTypes.facebook
 
     /// The JSON payload containing the accessToken.
     public var payload: Document {

--- a/StitchCore/StitchCore/Source/Auth/Providers/Google/GoogleAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/Google/GoogleAuthProvider.swift
@@ -5,7 +5,7 @@ import ExtendedJson
 public struct GoogleAuthProvider: AuthProvider {
     /// The authentication type for google login.
     public var type: String {
-        return "oauth2-google"
+        return AuthProviderTypes.google.rawValue
     }
 
     /// The JSON payload containing the authCode.

--- a/StitchCore/StitchCore/Source/Auth/Providers/Google/GoogleAuthProvider.swift
+++ b/StitchCore/StitchCore/Source/Auth/Providers/Google/GoogleAuthProvider.swift
@@ -4,9 +4,7 @@ import ExtendedJson
 /// GoogleAuthProvider provides a way to authenticate via Google's OAuth 2.0 provider.
 public struct GoogleAuthProvider: AuthProvider {
     /// The authentication type for google login.
-    public var type: String {
-        return AuthProviderTypes.google.rawValue
-    }
+    public var type: AuthProviderTypes = AuthProviderTypes.google
 
     /// The JSON payload containing the authCode.
     public var payload: Document {

--- a/StitchCore/StitchCore/Source/Core/StitchClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchClient.swift
@@ -130,7 +130,8 @@ public class StitchClient: StitchClientType {
         return self.httpClient.isAuthenticated
     }
 
-    // Returns the type of the provider used to log into the current session. nil if not authenticated or if unknown auth provider type
+    // Returns the type of the provider used to log into the current session.
+    //         nil if not authenticated or if unknown auth provider type
     public var loggedInProviderType: AuthProviderTypes? {
         if let rawProviderType = userDefaults?.string(forKey: Consts.AuthProviderTypeUDKey) {
             return AuthProviderTypes(rawValue: rawProviderType)
@@ -298,7 +299,7 @@ public class StitchClient: StitchClientType {
                 }
         }
 
-        guard self.isAuthenticated, let auth = self.auth else {
+        guard let userId = self.auth?.userId else {
             // Not currently authenticated, perform login.
             return doLoginRequest()
         }
@@ -307,7 +308,7 @@ public class StitchClient: StitchClientType {
         if provider.type == AuthProviderTypes.anonymous &&
             self.loggedInProviderType == AuthProviderTypes.anonymous {
             printLog(.info, text: "Already logged in as anonymous user, using cached token.")
-            return Promise.init(value: auth.userId)
+            return Promise.init(value: userId)
         }
 
         // Using a different provider, log out and then perform login.

--- a/StitchCore/StitchCore/Source/Core/StitchClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchClient.swift
@@ -306,9 +306,6 @@ public class StitchClient: StitchClientType {
             printLog(.info, text: "Already logged in, logging out of existing session.")
             return self.logout().then {
                 return doLoginRequest()
-            }.recover { _ -> Promise<UserId> in
-                printLog(.info, text: "Error logging out of existing session. Logging in with new user anyway.")
-                return doLoginRequest()
             }
         }
 
@@ -333,7 +330,12 @@ public class StitchClient: StitchClientType {
             $0.endpoint = self.routes.authSessionRoute
             $0.refreshOnFailure = false
             $0.useRefreshToken = true
+        }.recover { _ in
+            // We don't really care about errors in doing the request.
+            // Try clearing auth, but throw again if it fails.
+            return Promise.init(value: true)
         }.done { _ in
+            // This block will always be reached regardless of whether doRequest fails or succeeds
             try self.clearAuth()
         }
     }

--- a/StitchCore/StitchCore/Source/Core/StitchClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchClient.swift
@@ -129,10 +129,10 @@ public class StitchClient: StitchClientType {
     public var isAuthenticated: Bool {
         return self.httpClient.isAuthenticated
     }
-    
+
     // Returns the type of the provider used to log into the current session. nil if not authenticated
     public var loggedInProviderType: String? {
-        return self.httpClient.loggedInProviderType
+        return userDefaults?.string(forKey: Consts.AuthProviderTypeUDKey)
     }
 
     // MARK: - Init
@@ -302,9 +302,12 @@ public class StitchClient: StitchClientType {
                 return Promise.init(value: auth.userId)
             }
 
-            // Using a different provider, log outand then perform login.
+            // Using a different provider, log out and then perform login.
             printLog(.info, text: "Already logged in, logging out of existing session.")
             return self.logout().then {
+                return doLoginRequest()
+            }.recover { _ -> Promise<UserId> in
+                printLog(.info, text: "Error logging out of existing session. Logging in with new user anyway.")
                 return doLoginRequest()
             }
         }

--- a/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
@@ -48,6 +48,10 @@ internal class StitchHTTPClient {
 
         return authInfo != nil
     }
+    
+    public var loggedInProviderType: String? {
+        return userDefaults?.string(forKey: Consts.AuthProviderTypeUDKey)
+    }
 
     /**
      Determines if the access token stored in this Auth object is expired or expiring within
@@ -102,6 +106,8 @@ internal class StitchHTTPClient {
         try deleteToken(withKey: Consts.AuthRefreshTokenKey)
         try deleteToken(withKey: Consts.IsLoggedInUDKey)
         try deleteToken(withKey: Consts.AuthJwtKey)
+        
+        userDefaults?.removeObject(forKey: Consts.AuthProviderTypeUDKey)
 
         self.networkAdapter.cancelAllRequests()
     }

--- a/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
@@ -48,10 +48,6 @@ internal class StitchHTTPClient {
 
         return authInfo != nil
     }
-    
-    public var loggedInProviderType: String? {
-        return userDefaults?.string(forKey: Consts.AuthProviderTypeUDKey)
-    }
 
     /**
      Determines if the access token stored in this Auth object is expired or expiring within

--- a/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
@@ -102,7 +102,7 @@ internal class StitchHTTPClient {
         try deleteToken(withKey: Consts.AuthRefreshTokenKey)
         try deleteToken(withKey: Consts.IsLoggedInUDKey)
         try deleteToken(withKey: Consts.AuthJwtKey)
-        
+
         userDefaults?.removeObject(forKey: Consts.AuthProviderTypeUDKey)
 
         self.networkAdapter.cancelAllRequests()


### PR DESCRIPTION
In this change I now keep track of the auth provider used to log into a session in a new UserDefaults key, I exposed that in the StitchClient, and I updated `login()` to use the expected semantics.

**Drive-by changes:**
- Updated the enum of AuthProviderTypes to be `internal` rather than `private` so I could compare the types in the `StitchClient`. 
- Changed the hardcoded types in each of the the auth providers to the raw value of the enum type