### PR TITLE
STITCH-1075: iOS SDK Add ability for a user to link to any non-anonymous identity

### DIFF
--- a/StitchCore/StitchCore/Source/Auth/AuthInfo.swift
+++ b/StitchCore/StitchCore/Source/Auth/AuthInfo.swift
@@ -1,7 +1,19 @@
 import Foundation
 
+protocol AuthResponse: Codable {
+    var userId: String { get }
+}
+
+internal struct LinkInfo: AuthResponse {
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+    }
+    
+    var userId: String
+}
+
 /// Auth represents the current authorization state of the client
-internal struct AuthInfo: Codable {
+internal struct AuthInfo: AuthResponse {
     enum CodingKeys: String, CodingKey {
         case accessToken = "access_token",
         userId = "user_id",
@@ -14,13 +26,13 @@ internal struct AuthInfo: Codable {
     let accessToken: DecodedJWT?
 
     // The user this session was created for.
-    let deviceId: String?
+    let deviceId: String
 
     // The user this session was created for.
     let userId: String
 
     // The refresh token to refresh an expired access token
-    internal var refreshToken: String?
+    internal var refreshToken: String
 
     internal func auth(with updatedAccessToken: String) -> AuthInfo {
         return AuthInfo(accessToken: try? DecodedJWT(jwt: updatedAccessToken),

--- a/StitchCore/StitchCore/Source/Auth/AuthInfo.swift
+++ b/StitchCore/StitchCore/Source/Auth/AuthInfo.swift
@@ -14,13 +14,13 @@ internal struct AuthInfo: Codable {
     let accessToken: DecodedJWT?
 
     // The user this session was created for.
-    let deviceId: String
+    let deviceId: String?
 
     // The user this session was created for.
     let userId: String
 
     // The refresh token to refresh an expired access token
-    internal var refreshToken: String
+    internal var refreshToken: String?
 
     internal func auth(with updatedAccessToken: String) -> AuthInfo {
         return AuthInfo(accessToken: try? DecodedJWT(jwt: updatedAccessToken),

--- a/StitchCore/StitchCore/Source/Core/StitchClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchClient.swift
@@ -150,8 +150,8 @@ public class StitchClient: StitchClientType {
         return self.httpClient.isAuthenticated
     }
 
-    // Returns the type of the provider used to log into the current session.
-    //         nil if not authenticated or if unknown auth provider type
+    // The type of the provider used to log into the current session, or the most recent
+    // provider linked. nil if not authenticated or if provider type is not recognized
     public var loggedInProviderType: AuthProviderTypes? {
         if let rawProviderType = userDefaults?.string(forKey: Consts.AuthProviderTypeUDKey) {
             return AuthProviderTypes(rawValue: rawProviderType)
@@ -298,30 +298,9 @@ public class StitchClient: StitchClientType {
      */
     @discardableResult
     public func login(withProvider provider: AuthProvider) -> Promise<UserId> {
-        self.authProvider = provider
-
-        func doLoginRequest() -> Promise<UserId> {
-            return httpClient.doRequest { request in
-                request.method = .post
-                request.endpoint = self.routes.authProvidersLoginRoute(provider: provider.type.rawValue)
-                request.isAuthenticatedRequest = false
-                try request.encode(withData: self.getAuthRequest(provider: provider))
-                }.flatMap { [weak self] any in
-                    guard let strongSelf = self else { throw StitchError.clientReleased }
-                    let authInfo = try JSONDecoder().decode(AuthInfo.self,
-                                                            from: JSONSerialization.data(withJSONObject: any))
-                    strongSelf.httpClient.authInfo = authInfo
-                    strongSelf._auth = Auth(stitchClient: strongSelf,
-                                            stitchHttpClient: strongSelf.httpClient,
-                                            userId: authInfo.userId)
-                    strongSelf.onLogin()
-                    return authInfo.userId
-                }
-        }
-
         guard let userId = self.auth?.userId else {
             // Not currently authenticated, perform login.
-            return doLoginRequest()
+            return self.doAuthRequest(withProvider: provider)
         }
 
         // Check if logging in as anonymous user while already logged in as anonymous user
@@ -334,7 +313,7 @@ public class StitchClient: StitchClientType {
         // Using a different provider, log out and then perform login.
         printLog(.info, text: "Already logged in, logging out of existing session.")
         return self.logout().then {
-            return doLoginRequest()
+            return self.doAuthRequest(withProvider: provider)
         }
     }
 
@@ -367,10 +346,61 @@ public class StitchClient: StitchClientType {
         }
     }
 
+    /**
+     * Links the current user to another identity.
+     *
+     * - Parameters:
+     * - withProvider: The authentication provider which will provide the new identity
+     *
+     * - Returns:
+     * - The user ID of the current, original user
+     */
+    @discardableResult
+    public func link(withProvider provider: AuthProvider) -> Promise<UserId> {
+        if !isAuthenticated {
+            return Promise.init(
+                error: StitchError.illegalAction(message: "Must be authenticated to link a user to new identity.")
+            )
+        }
+
+        return self.doAuthRequest(withProvider: provider, withLinking: true)
+    }
+
+    private func doAuthRequest(withProvider provider: AuthProvider,
+                               withLinking linking: Bool = false) -> Promise<UserId> {
+        return httpClient.doRequest { request in
+            request.method = .post
+
+            let authRoute = self.routes.authProvidersLoginRoute(provider: provider.type.rawValue)
+            request.endpoint = "\(authRoute)\(linking ? "?link=true" : "")"
+            request.isAuthenticatedRequest = linking
+
+            try request.encode(withData: self.getAuthRequest(provider: provider))
+            }.flatMap { [weak self] any in
+                guard let strongSelf = self else { throw StitchError.clientReleased }
+                let authInfo = try JSONDecoder().decode(AuthInfo.self,
+                                                        from: JSONSerialization.data(withJSONObject: any))
+                strongSelf.authProvider = provider
+                if !linking {
+                    strongSelf.httpClient.authInfo = authInfo
+                    strongSelf._auth = Auth(stitchClient: strongSelf,
+                                            stitchHttpClient: strongSelf.httpClient,
+                                            userId: authInfo.userId)
+                    strongSelf.onLogin()
+                } else {
+                    strongSelf.userDefaults?.set(strongSelf.authProvider?.type.rawValue,
+                                                 forKey: Consts.AuthProviderTypeUDKey)
+                }
+
+                return authInfo.userId
+        }
+    }
+
     // MARK: Private
     internal func clearAuth() throws {
         onLogout()
 
+        self.authProvider = nil
         try self.httpClient.clearAuth()
     }
 

--- a/StitchCore/StitchCore/Source/Core/StitchClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchClient.swift
@@ -399,7 +399,6 @@ public class StitchClient: StitchClientType {
         }
     }
 
-    
     internal func clearAuth() throws {
         onLogout()
 

--- a/StitchCore/StitchCoreTests/AuthTests.swift
+++ b/StitchCore/StitchCoreTests/AuthTests.swift
@@ -124,16 +124,20 @@ class AuthTests: XCTestCase {
     
     func testMultipleLoginSemantics() throws {
         let exp = expectation(description: "multiple logins work as expected")
-        let mlsStitchClient = StitchClient(appId: "stitch-tests-ios-sdk-jjmum")
+        var mlsStitchClient: StitchClient! = nil
         var anonUserId = ""
         var emailUserId = ""
         
-        // check storage
-        XCTAssertFalse(mlsStitchClient.isAuthenticated)
-        XCTAssertNil(mlsStitchClient.loggedInProviderType)
-        
-        // login anonymously
-        mlsStitchClient.login(withProvider: AnonymousAuthProvider()).then { (userId: String) -> Promise<String> in
+        StitchClientFactory.create(appId: "stitch-tests-ios-sdk-jjmum").then { (client: StitchClient) -> Promise<String> in
+            mlsStitchClient = client
+            
+            // check storage
+            XCTAssertFalse(mlsStitchClient.isAuthenticated)
+            XCTAssertNil(mlsStitchClient.loggedInProviderType)
+            
+            // login anonymously
+            return mlsStitchClient.login(withProvider: AnonymousAuthProvider())
+        }.then { (userId: String) -> Promise<String> in
             anonUserId = userId
             
             // check storage

--- a/StitchCore/StitchCoreTests/AuthTests.swift
+++ b/StitchCore/StitchCoreTests/AuthTests.swift
@@ -198,15 +198,19 @@ class AuthTests: XCTestCase {
     /*
     func testIdentityLinking() throws {
         let exp = expectation(description: "identity linking works as expected")
-        let ilStitchClient = StitchClient(appId: "stitch-tests-ios-sdk-jjmum")
-
+        var ilStitchClient: StitchClient! = nil
         var firstUserId = ""
 
-        ilStitchClient.login(withProvider: AnonymousAuthProvider()).then{ (userId: String) -> Promise<String> in
+        StitchClientFactory.create(appId: "stitch-tests-ios-sdk-jjmum").then { (client: StitchClient) -> Promise<String> in
+            ilStitchClient = client
+            
+            // login anonymously
+            return ilStitchClient.login(withProvider: AnonymousAuthProvider())
+        }.then{ (userId: String) -> Promise<String> in
             XCTAssertEqual(ilStitchClient.loggedInProviderType, AuthProviderTypes.anonymous)
 
             firstUserId = userId
-            return ilStitchClient.link(withProvider: EmailPasswordAuthProvider(username: "linktest0@example.com", password: "hunter2"))
+            return ilStitchClient.link(withProvider: EmailPasswordAuthProvider(username: "link_test@10gen.com", password: "hunter2"))
         }.then { (newUserId: String) -> Promise<UserProfile> in
             XCTAssertEqual(firstUserId, newUserId)
             XCTAssertEqual(ilStitchClient.loggedInProviderType, AuthProviderTypes.emailPass)

--- a/StitchCore/StitchCoreTests/AuthTests.swift
+++ b/StitchCore/StitchCoreTests/AuthTests.swift
@@ -187,4 +187,41 @@ class AuthTests: XCTestCase {
         
         wait(for: [exp], timeout: 10)
     }
+
+    // NOTE: This test works locally when logging in with an email identity not associated with a Stitch user, but with our
+    // current testing framework we cannot dynamically create identities to test this functionality. Once we have the
+    // appropriate framework we can re-enable this test.
+    /*
+    func testIdentityLinking() throws {
+        let exp = expectation(description: "identity linking works as expected")
+        let ilStitchClient = StitchClient(appId: "stitch-tests-ios-sdk-jjmum")
+
+        var firstUserId = ""
+
+        ilStitchClient.login(withProvider: AnonymousAuthProvider()).then{ (userId: String) -> Promise<String> in
+            XCTAssertEqual(ilStitchClient.loggedInProviderType, AuthProviderTypes.anonymous)
+
+            firstUserId = userId
+            return ilStitchClient.link(withProvider: EmailPasswordAuthProvider(username: "linktest0@example.com", password: "hunter2"))
+        }.then { (newUserId: String) -> Promise<UserProfile> in
+            XCTAssertEqual(firstUserId, newUserId)
+            XCTAssertEqual(ilStitchClient.loggedInProviderType, AuthProviderTypes.emailPass)
+
+            return ilStitchClient.auth!.fetchUserProfile()
+        }.then { (userProfile: UserProfile) -> Promise<Void> in
+            XCTAssertEqual(userProfile.identities.count, 2)
+
+            return ilStitchClient.logout()
+        }.done {
+            XCTAssertFalse(ilStitchClient.isAuthenticated)
+            exp.fulfill()
+        }.catch { err in
+            print(err)
+            XCTFail(err.localizedDescription)
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 10)
+    }
+    */
 }


### PR DESCRIPTION
This change adds linking functionality to the iOS SDK. Should be functionally identical to the JS SDK changes, except that linking in the iOS SDK does not attempt to update the underlying auth object of StitchClient. I also made `loggedInProvider` always reflect the most recently linked identity to match the behavior of the JS SDK.

I tested this locally with an emal/password identity but until we can use the admin API in our tests it’s going to be difficult to test this. I left the test in as a comment.

**Drive-bys:**
- Made StitchClient in multiple login semantics test conform to new factory pattern
- Made `deviceID` and `refreshToken` optional in `AuthInfo` struct so the `decode()` doesn’t fail when getting the linking auth response
- refactored the `doLoginRequest()` closure from `login()` into a `doAuthRequest()` method that is called from both `login()` and `link()` with slightly different parameters.
