### PR TITLE
STITCH-1175 correctly delete isLoggedInUDKey in clearAuth()

### DIFF
--- a/StitchCore/StitchCore/Source/Core/StitchClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchClient.swift
@@ -414,8 +414,8 @@ public class StitchClient: StitchClientType {
                 } else {
                     let linkInfo = try JSONDecoder().decode(LinkInfo.self,
                                                             from: JSONSerialization.data(withJSONObject: json))
-                    strongSelf.userDefaults?.set(strongSelf.authProvider?.type.rawValue,
-                                                 forKey: Consts.AuthProviderTypeUDKey)
+                    strongSelf.storage.set(strongSelf.authProvider?.type.rawValue,
+                                           forKey: strongSelf.storageKeys.authProviderTypeUDKey)
                     return linkInfo.userId
                 }
         }

--- a/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
@@ -109,9 +109,9 @@ internal class StitchHTTPClient {
         authInfo = nil
 
         try deleteToken(withKey: self.storageKeys.authRefreshTokenKey)
-        try deleteToken(withKey: self.storageKeys.isLoggedInUDKey)
         try deleteToken(withKey: self.storageKeys.authJwtKey)
 
+        self.storage.set(false, forKey: self.storageKeys.isLoggedInUDKey)
         self.storage.removeObject(forKey: self.storageKeys.authProviderTypeUDKey)
 
         self.networkAdapter.cancelAllRequests()

--- a/StitchCore/StitchCoreTests/AuthTests.swift
+++ b/StitchCore/StitchCoreTests/AuthTests.swift
@@ -65,6 +65,27 @@ class AuthTests: XCTestCase {
         }
         wait(for: [exp], timeout: 10)
     }
+    
+    func testAuthStorage() throws {
+        let exp = expectation(description: "login status and provider stored when logging in and cleared when logging out")
+        
+        stitchClient.login(withProvider: AnonymousAuthProvider()).then { (userId: String) -> Promise<Void> in
+            print(userId)
+            XCTAssertTrue(self.stitchClient.storage.value(forKey: self.stitchClient.storageKeys.isLoggedInUDKey) as? Bool ?? false)
+            XCTAssertNotNil(self.stitchClient.storage.value(forKey: self.stitchClient.storageKeys.authProviderTypeUDKey))
+            
+            return self.stitchClient.logout()
+        }.done {
+            XCTAssertFalse(self.stitchClient.storage.value(forKey: self.stitchClient.storageKeys.isLoggedInUDKey) as? Bool ?? true)
+            XCTAssertNil(self.stitchClient.storage.value(forKey: self.stitchClient.storageKeys.authProviderTypeUDKey))
+        
+            exp.fulfill()
+        }.catch { err in
+            print(err)
+            XCTFail(err.localizedDescription)
+        }
+        wait(for: [exp], timeout: 10)
+    }
 
     func testUserProfile() throws {
         let exp = expectation(description: "user profile matched")


### PR DESCRIPTION
Really small fix with one drive-by change to fix compilation since a method was referencing userDefaults instead of storage. Didn't write any tests since the multiple login semantics test should catch this case when running on an iPhone.