### PR TITLE
fix token refresh

### DIFF
--- a/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
+++ b/StitchCore/StitchCore/Source/Core/StitchHTTPClient.swift
@@ -172,7 +172,7 @@ internal class StitchHTTPClient {
             }
 
             guard let json = any as? [String: String],
-                let accessToken = json["auth_info"],
+                let accessToken = json["access_token"],
                     let authInfo = strongSelf.authInfo else {
                         throw StitchError.unauthorized(message: "not authenticated")
                 }


### PR DESCRIPTION
token refresh was looking for "auth_info" and not "access_token" in the session post response