### PR TITLE
STITCH-1354 Refactor error handling

### DIFF
--- a/StitchCore-iOS/StitchCore-iOS/Core/Auth/Internal/StitchAuthImpl.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Auth/Internal/StitchAuthImpl.swift
@@ -117,13 +117,19 @@ internal final class StitchAuthImpl: CoreStitchAuth<StitchUserImpl>, StitchAuth 
     }
 
     /**
-     * Logs out the currently authenticated user, and clears any persisted
-     * authentication information.
+     * Links the currently authenticated user with a new identity, where the identity is defined by the credential
+     * specified as a parameter. This will only be successful if this `StitchUser` is the currently authenticated
+     * `StitchUser` for the client from which it was created.
      *
      * - parameters:
-     *     - completionHandler: The completion handler to call when the logout is complete.
+     *     - withCredential: The `StitchCore.StitchCredential` used to link the user to a new
+     *                       identity. Credentials can be retrieved from an
+     *                       authentication provider client, which is retrieved
+     *                       using the `getProviderClient` method on `StitchAuth`.
+     *     - completionHandler: The completion handler to call when the linking is complete.
      *                          This handler is executed on a non-main global `DispatchQueue`.
-     *     - error: An error object that indicates why the logout failed, or `nil` if the logout was successful.
+     *     - user: The current user, or `nil` if the link failed.
+     *     - error: An error object that indicates why the link failed, or `nil` if the link was successful.
      */
     internal func link(withCredential credential: StitchCredential,
                        withUser user: StitchUserImpl,
@@ -133,9 +139,18 @@ internal final class StitchAuthImpl: CoreStitchAuth<StitchUserImpl>, StitchAuth 
         }
     }
 
+    /**
+     * Logs out the currently authenticated user, and clears any persisted authentication information.
+     *
+     * - parameters:
+     *     - completionHandler: The completion handler to call when the logout is complete.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     *     - error: Will always be nil, since the underlying implementation squashes errors and always clears local
+     *              authentication information.
+     */
     public func logout(_ completionHandler: @escaping ((Error?) -> Void)) {
         dispatcher.run(withCompletionHandler: completionHandler) {
-            try self.logoutBlocking()
+            self.logoutBlocking()
         }
     }
 

--- a/StitchCore-iOS/StitchCore-iOS/Core/Auth/StitchAuth.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Auth/StitchAuth.swift
@@ -77,7 +77,8 @@ public protocol StitchAuth {
      * - parameters:
      *     - completionHandler: The completion handler to call when the logout is complete.
      *                          This handler is executed on a non-main global `DispatchQueue`.
-     *     - error: An error object that indicates why the logout failed, or `nil` if the logout was successful.
+     *     - error: Will always be nil, since the underlying implementation squashes errors and always clears local
+     *              authentication information.
      */
     func logout(_ completionHandler: @escaping (_ error: Error?) -> Void)
 

--- a/StitchCore-iOS/StitchCore-iOS/Core/StitchCore.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/StitchCore.swift
@@ -7,6 +7,7 @@ import Foundation
 @_exported import protocol StitchCore.StitchUserProfile
 @_exported import protocol StitchCore.StitchUserIdentity
 
+@_exported import enum StitchCore.StitchAppClientConfigurationError
 @_exported import enum StitchCore.StitchError
 @_exported import enum StitchCore.StitchClientError
 @_exported import enum StitchCore.StitchErrorCode

--- a/StitchCore-iOS/StitchCore-iOS/Core/StitchCore.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/StitchCore.swift
@@ -9,5 +9,5 @@ import Foundation
 
 @_exported import enum StitchCore.StitchAppClientConfigurationError
 @_exported import enum StitchCore.StitchError
-@_exported import enum StitchCore.StitchClientError
-@_exported import enum StitchCore.StitchErrorCode
+@_exported import enum StitchCore.StitchClientErrorCode
+@_exported import enum StitchCore.StitchServiceErrorCode

--- a/StitchCore-iOS/StitchCore-iOS/Core/StitchCore.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/StitchCore.swift
@@ -9,5 +9,6 @@ import Foundation
 
 @_exported import enum StitchCore.StitchAppClientConfigurationError
 @_exported import enum StitchCore.StitchError
-@_exported import enum StitchCore.StitchClientErrorCode
 @_exported import enum StitchCore.StitchServiceErrorCode
+@_exported import enum StitchCore.StitchRequestErrorCode
+@_exported import enum StitchCore.StitchClientErrorCode

--- a/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth+StitchAuthRequestClient.swift
+++ b/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth+StitchAuthRequestClient.swift
@@ -30,7 +30,7 @@ extension CoreStitchAuth: StitchAuthRequestClient {
             let response = try doAuthenticatedJSONRequestRaw(stitchReq)
 
             guard let responseBody = response.body else {
-                throw StitchError.unknownError(withMessage: nil)
+                throw StitchError.serviceError(withMessage: nil, withServiceErrorCode: .unknown)
             }
 
             return try JSONSerialization.jsonObject(with: responseBody,
@@ -70,7 +70,7 @@ extension CoreStitchAuth: StitchAuthRequestClient {
         guard self.isLoggedIn,
             let refreshToken = self.authStateHolder.refreshToken,
             let accessToken = self.authStateHolder.accessToken else {
-                throw StitchClientError.mustAuthenticateFirst
+                throw StitchError.clientError(withClientErrorCode: .mustAuthenticateFirst)
         }
 
         return try StitchRequestBuilderImpl {
@@ -133,7 +133,7 @@ extension CoreStitchAuth: StitchAuthRequestClient {
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
         guard isLoggedIn, let accessToken = self.authStateHolder.accessToken else {
-            throw StitchClientError.loggedOutDuringRequest
+            throw StitchError.clientError(withClientErrorCode: .loggedOutDuringRequest)
         }
 
         let jwt = try DecodedJWT.init(jwt: accessToken)

--- a/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth+StitchAuthRequestClient.swift
+++ b/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth+StitchAuthRequestClient.swift
@@ -30,7 +30,7 @@ extension CoreStitchAuth: StitchAuthRequestClient {
             let response = try doAuthenticatedJSONRequestRaw(stitchReq)
 
             guard let responseBody = response.body else {
-                throw StitchError.requestError(withMessage: "no body in request response")
+                throw StitchError.unknownError(withMessage: nil)
             }
 
             return try JSONSerialization.jsonObject(with: responseBody,
@@ -106,7 +106,7 @@ extension CoreStitchAuth: StitchAuthRequestClient {
             guard withErrorCode == .invalidSession else {
                 throw error
             }
-        case .requestError:
+        default:
             throw error
         }
 
@@ -133,7 +133,7 @@ extension CoreStitchAuth: StitchAuthRequestClient {
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
         guard isLoggedIn, let accessToken = self.authStateHolder.accessToken else {
-            throw StitchError.requestError(withMessage: "logged out during request")
+            throw StitchClientError.loggedOutDuringRequest
         }
 
         let jwt = try DecodedJWT.init(jwt: accessToken)

--- a/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth.swift
+++ b/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth.swift
@@ -198,7 +198,7 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
         defer { objc_sync_exit(self) }
         guard let currentUser = self.currentUser,
             user == currentUser else {
-            throw StitchClientError.userNoLongerValid
+            throw StitchError.clientError(withClientErrorCode: .userNoLongerValid)
         }
 
         return try self.doLogin(withCredential: credential, asLinkRequest: true)
@@ -301,7 +301,7 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
     private func processLoginResponse(withCredential credential: StitchCredential,
                                       forResponse response: Response) throws -> TStitchUser {
         guard let body = response.body else {
-            throw StitchError.unknownError(withMessage: nil)
+            throw StitchError.serviceError(withMessage: nil, withServiceErrorCode: .unknown)
         }
 
         let decodedInfo = try JSONDecoder().decode(APIAuthInfoImpl.self, from: body)

--- a/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth.swift
+++ b/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth.swift
@@ -70,7 +70,11 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
         self.authRoutes = authRoutes
         self.storage = storage
 
-        self.authStateHolder.authInfo = try StoreAuthInfo.read(fromStorage: storage)
+        do {
+            self.authStateHolder.authInfo = try StoreAuthInfo.read(fromStorage: storage)
+        } catch {
+            throw StitchError.clientError(withClientErrorCode: .couldNotLoadPersistedAuthInfo)
+        }
 
         if let authInfo = authInfo {
             // this implies other properties we are interested should be set
@@ -184,7 +188,7 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
             }
         }
 
-        try logoutBlocking()
+        logoutBlocking()
         return try doLogin(withCredential: credential, asLinkRequest: false)
     }
 
@@ -207,21 +211,13 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
     /**
      * Logs out the current user, and clears authentication state from this `CoreStitchAuth` as well as underlying
      * storage. Blocks the current thread until the request is completed. If the logout request fails, this method will
-     * still attempt to clear local authentication state. This method will only throw if clearing authentication state
-     * fails.
+     * still clear local authentication state.
      */
-    public func logoutBlocking() throws {
+    public func logoutBlocking() {
         guard isLoggedIn else { return }
 
-        do {
-            try doLogout()
-        } catch StitchError.serviceError {
-        } catch let err {
-            try clearAuth()
-            throw err
-        }
-
-        try clearAuth()
+        _ = try? self.doLogout()
+        clearAuth()
     }
 
     // MARK: Internal Methods
@@ -233,13 +229,10 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
      * - important: Callers of `doLogin` should be synchronized before calling in.
      */
     private func doLogin(withCredential credential: StitchCredential, asLinkRequest: Bool) throws -> TStitchUser {
-        let response = try self.doLoginRequest(withCredential: credential,
-                                               asLinkRequest: asLinkRequest)
-        let user = try self.processLoginResponse(withCredential: credential,
-                                                 forResponse: response)
+        let response = try self.doLoginRequest(withCredential: credential, asLinkRequest: asLinkRequest)
+        let user = try self.processLoginResponse(withCredential: credential, forResponse: response)
 
         onAuthEvent()
-
         return user
     }
 
@@ -257,9 +250,7 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
      * the login request.
      */
     private func attachAuthOptions(authBody: inout Document) {
-        authBody[AuthKey.options.rawValue] = [
-            AuthKey.device.rawValue: deviceInfo
-            ] as Document
+        authBody[AuthKey.options.rawValue] = [AuthKey.device.rawValue: deviceInfo] as Document
     }
 
     /**
@@ -301,10 +292,18 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
     private func processLoginResponse(withCredential credential: StitchCredential,
                                       forResponse response: Response) throws -> TStitchUser {
         guard let body = response.body else {
-            throw StitchError.serviceError(withMessage: nil, withServiceErrorCode: .unknown)
+            throw StitchError.serviceError(
+                withMessage: StitchErrorCodable.genericErrorMessage(withStatusCode: response.statusCode),
+                withServiceErrorCode: .unknown
+            )
         }
 
-        let decodedInfo = try JSONDecoder().decode(APIAuthInfoImpl.self, from: body)
+        var decodedInfo: APIAuthInfoImpl!
+        do {
+            decodedInfo = try JSONDecoder().decode(APIAuthInfoImpl.self, from: body)
+        } catch {
+            throw StitchError.requestError(withError: error, withRequestErrorCode: .decodingError)
+        }
 
         // Provisionally set so we can make a profile request
         if self.authInfo == nil {
@@ -319,7 +318,7 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
         do {
             profile = try doGetUserProfile()
         } catch let err {
-            try self.logoutBlocking()
+            self.logoutBlocking()
             throw err
         }
 
@@ -328,10 +327,14 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
             withAPIAuthInfo: decodedInfo,
             withExtendedAuthInfo: ExtendedAuthInfoImpl.init(loggedInProviderType: type(of: credential).providerType,
                                                             loggedInProviderName: credential.providerName,
-                                                            userProfile: profile)
-        )
+                                                            userProfile: profile))
 
-        try self.authInfo?.write(toStorage: &storage)
+        do {
+            try self.authInfo?.write(toStorage: &storage)
+        } catch {
+            throw StitchError.clientError(withClientErrorCode: .couldNotPersistAuthInfo)
+        }
+
         self.currentUser =
             userFactory
                 .makeUser(
@@ -351,8 +354,12 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
             $0.path = self.authRoutes.profileRoute
         }.build())
 
-        let decodedProfile = try JSONDecoder.init().decode(APICoreUserProfileImpl.self,
-                                                           from: response.body!)
+        var decodedProfile: APICoreUserProfileImpl!
+        do {
+            decodedProfile = try JSONDecoder.init().decode(APICoreUserProfileImpl.self, from: response.body!)
+        } catch {
+            throw StitchError.requestError(withError: error, withRequestErrorCode: .decodingError)
+        }
 
         return StitchUserProfileImpl.init(userType: decodedProfile.userType,
                                           identities: decodedProfile.identities,
@@ -375,7 +382,7 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
      * Clears the `CoreStitchAuth`'s authentication state, as well as associated authentication state in underlying
      * storage.
      */
-    internal func clearAuth() throws {
+    internal func clearAuth() {
         objc_sync_enter(self)
         defer { objc_sync_exit(self) }
         guard self.isLoggedIn else { return }

--- a/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth.swift
+++ b/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth.swift
@@ -198,8 +198,7 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
         defer { objc_sync_exit(self) }
         guard let currentUser = self.currentUser,
             user == currentUser else {
-            throw StitchError.requestError(
-                withMessage: "user no longer valid; please try again with a new user from StitchAuth.user")
+            throw StitchClientError.userNoLongerValid
         }
 
         return try self.doLogin(withCredential: credential, asLinkRequest: true)
@@ -302,7 +301,7 @@ open class CoreStitchAuth<TStitchUser> where TStitchUser: CoreStitchUser {
     private func processLoginResponse(withCredential credential: StitchCredential,
                                       forResponse response: Response) throws -> TStitchUser {
         guard let body = response.body else {
-            throw StitchErrorCode.missingAuthReq
+            throw StitchError.unknownError(withMessage: nil)
         }
 
         let decodedInfo = try JSONDecoder().decode(APIAuthInfoImpl.self, from: body)

--- a/StitchCore/Sources/StitchCore/Internal/Net/FoundationHTTPTransport.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/FoundationHTTPTransport.swift
@@ -56,7 +56,10 @@ public final class FoundationHTTPTransport: Transport {
 
         guard let response = finalResponse else {
             guard let err = error else {
-                throw StitchError.serviceError(withMessage: nil, withServiceErrorCode: .unknown)
+                throw StitchError.serviceError(
+                    withMessage: "no response from server",
+                    withServiceErrorCode: .unknown
+                )
             }
 
             throw err

--- a/StitchCore/Sources/StitchCore/Internal/Net/FoundationHTTPTransport.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/FoundationHTTPTransport.swift
@@ -15,7 +15,7 @@ public final class FoundationHTTPTransport: Transport {
      */
     public func roundTrip(request: Request) throws -> Response {
         guard let url = URL(string: request.url) else {
-            throw StitchErrorCode.invalidURL
+            throw StitchClientError.missingURL
         }
 
         let defaultSession = URLSession(configuration: URLSessionConfiguration.default)
@@ -56,7 +56,7 @@ public final class FoundationHTTPTransport: Transport {
 
         guard let response = finalResponse else {
             guard let err = error else {
-                throw StitchErrorCode.unknown
+                throw StitchError.unknownError(withMessage: nil)
             }
 
             throw err

--- a/StitchCore/Sources/StitchCore/Internal/Net/FoundationHTTPTransport.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/FoundationHTTPTransport.swift
@@ -15,7 +15,7 @@ public final class FoundationHTTPTransport: Transport {
      */
     public func roundTrip(request: Request) throws -> Response {
         guard let url = URL(string: request.url) else {
-            throw StitchClientError.missingURL
+            throw StitchError.clientError(withClientErrorCode: .missingURL)
         }
 
         let defaultSession = URLSession(configuration: URLSessionConfiguration.default)
@@ -56,7 +56,7 @@ public final class FoundationHTTPTransport: Transport {
 
         guard let response = finalResponse else {
             guard let err = error else {
-                throw StitchError.unknownError(withMessage: nil)
+                throw StitchError.serviceError(withMessage: nil, withServiceErrorCode: .unknown)
             }
 
             throw err

--- a/StitchCore/Sources/StitchCore/Internal/Net/StitchRequestClient.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/StitchRequestClient.swift
@@ -7,7 +7,7 @@ import ExtendedJSON
 private func inspectResponse(response: Response) throws -> Response {
     guard response.statusCode >= 200,
         response.statusCode < 300 else {
-        throw StitchErrorCodable.handleRequestError(response: response)
+        throw StitchErrorCodable.handleError(inResponse: response)
     }
 
     return response

--- a/StitchCore/Sources/StitchCore/Internal/Net/StitchRequestClient.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/StitchRequestClient.swift
@@ -65,9 +65,14 @@ public final class StitchRequestClientImpl: StitchRequestClient {
      * - returns: the response to the request as a `Response` object.
      */
     public func doRequest<R>(_ stitchReq: R) throws -> Response where R: StitchRequest {
-        return try inspectResponse(
-            response: transport.roundTrip(request: buildRequest(stitchReq))
-        )
+        do {
+            return try inspectResponse(
+                response: transport.roundTrip(request: buildRequest(stitchReq))
+            )
+        } catch {
+            // Wrap the error from the transport in a `StitchError.requestError`
+            throw StitchError.requestError(withError: error)
+        }
     }
 
     /**

--- a/StitchCore/Sources/StitchCore/Internal/Net/StitchRequestClient.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/StitchRequestClient.swift
@@ -7,7 +7,7 @@ import ExtendedJSON
 private func inspectResponse(response: Response) throws -> Response {
     guard response.statusCode >= 200,
         response.statusCode < 300 else {
-        throw StitchErrorCodable.handleError(inResponse: response)
+        throw StitchErrorCodable.handleError(forResponse: response)
     }
 
     return response
@@ -65,14 +65,15 @@ public final class StitchRequestClientImpl: StitchRequestClient {
      * - returns: the response to the request as a `Response` object.
      */
     public func doRequest<R>(_ stitchReq: R) throws -> Response where R: StitchRequest {
+        var response: Response!
         do {
-            return try inspectResponse(
-                response: transport.roundTrip(request: buildRequest(stitchReq))
-            )
+            response = try transport.roundTrip(request: buildRequest(stitchReq))
         } catch {
             // Wrap the error from the transport in a `StitchError.requestError`
-            throw StitchError.requestError(withError: error)
+            throw StitchError.requestError(withError: error, withRequestErrorCode: .transportError)
         }
+
+        return try inspectResponse(response: response)
     }
 
     /**

--- a/StitchCore/Sources/StitchCore/StitchError.swift
+++ b/StitchCore/Sources/StitchCore/StitchError.swift
@@ -17,7 +17,7 @@ public enum StitchError: Error {
     case serviceError(withMessage: String?, withServiceErrorCode: StitchServiceErrorCode)
 
     /**
-     * Indicates that an error occured while a request was being carried out. This could be due to (but is not
+     * Indicates that an error occurred while a request was being carried out. This could be due to (but is not
      * limited to) an unreachable server or a connection timeout. These errors are thrown by the underlying `Transport`
      * of the Stitch client, and thus contain the error that the transport threw. For the default transport, these
      * errors will be `NSError`s in the `NSURLErrorDomain` domain.
@@ -25,7 +25,7 @@ public enum StitchError: Error {
     case requestError(withError: Error)
 
     /**
-     * Indicates that the error occured before the client performed a request. An error code describing the reason
+     * Indicates that the error occured before the client performed a request. An error code indicating the reason
      * for the error is included.
      */
     case clientError(withClientErrorCode: StitchClientErrorCode)

--- a/StitchCore/Sources/StitchCore/StitchError.swift
+++ b/StitchCore/Sources/StitchCore/StitchError.swift
@@ -1,34 +1,40 @@
 import Foundation
 
 /**
- * An enum representing an error returned from a server upon a completed request
- *
- * - important: A `StitchError` is only thrown if a request to a server has been completed. Transport-related errors,
- *              such as being unable to connect to a server, are thrown by the underlying `Transport` that the Stitch
- *              client is configured with, and will not be one of these errors. If no `Transport` is specified,
- *              transport errors will be ones that are normally thrown by `URLSession.dataTask`.
+ * An enum representing the types of errors that may be thrown by the Stitch SDK.
  */
 public enum StitchError: Error {
     /**
-     * Indicates that the error was specifically from a Stitch server, with an error message and an error code
-     * defined in the `StitchErrorCode` enum.
+     * Indicates that an error came from the Stitch server after a request was completed, with an error message and an
+     * error defined in the `StitchServiceErrorCode` enum.
+     *
+     * It is possible that the error code will be
+     * `StitchServiceErrorCode.unknown`, which can mean one of several possibilities: the Stitch server returned a
+     * message that this version of the SDK does not yet recognize, the server is not a Stitch server and returned an
+     * unexpected message, or the response was corrupted. In these cases, the associated message will be the plain text
+     * body of the response, or `nil` if the body is empty or not decodable as plain text.
      */
-    case serviceError(withMessage: String, withErrorCode: StitchErrorCode)
+    case serviceError(withMessage: String?, withServiceErrorCode: StitchServiceErrorCode)
 
     /**
-     * Indicates that the error type received from the server is not known. This may be due to a corrupted
-     * response, an error unrelated to Stitch (perhaps the server being contacted is not actually a Stitch server), or
-     * a new type of error that this version of the Stitch iOS SDK does not currently recognize. The error will be
-     * accompanied with a message unless the response was empty or could not be decoded as JSON or UTF-8 plaintext.
+     * Indicates that an error occured while a request was being carried out. This could be due to (but is not
+     * limited to) an unreachable server or a connection timeout. These errors are thrown by the underlying `Transport`
+     * of the Stitch client, and thus contain the error that the transport threw. For the default transport, these
+     * errors will be `NSError`s in the `NSURLErrorDomain` domain.
      */
-    case unknownError(withMessage: String?)
+    case requestError(withError: Error)
+
+    /**
+     * Indicates that the error occured before the client performed a request. An error code describing the reason
+     * for the error is included.
+     */
+    case clientError(withClientErrorCode: StitchClientErrorCode)
 }
 
 /**
- * An enumeration indicating the errors that may occur when using a Stitch client. These errors are thrown
- * before the client performs any request against the server.
+ * An enumeration indicating the types of errors that may occur when using a Stitch client, before the request is made.
  */
-public enum StitchClientError: Error {
+public enum StitchClientErrorCode {
     case loggedOutDuringRequest
     case missingURL
     case mustAuthenticateFirst
@@ -36,10 +42,10 @@ public enum StitchClientError: Error {
 }
 
 /**
- * An enumeration of the types of errors that can come back from a completed request to the Stitch server. These are
- * the error codes as they are returned by the Stitch server in an error response.
+ * An enumeration of the types of errors that can come back from a completed request to the Stitch server. With the
+ * exception of `.unknown`, these are the error codes as they are returned by the Stitch server in an error response.
  */
-public enum StitchErrorCode: String, Codable, Error {
+public enum StitchServiceErrorCode: String, Codable {
     case missingAuthReq = "MissingAuthReq",
     /// Invalid session, expired, no associated user, or app domain mismatch
     invalidSession = "InvalidSession",
@@ -86,7 +92,8 @@ public enum StitchErrorCode: String, Codable, Error {
     notCallable = "FunctionNotCallable",
     userAlreadyConfirmed = "UserAlreadyConfirmed",
     userNotFound = "UserNotFound",
-    userDisabled = "UserDisabled"
+    userDisabled = "UserDisabled",
+    unknown = "Unknown"
 }
 
 /**
@@ -106,25 +113,25 @@ internal struct StitchErrorCodable: Codable {
     /**
      * The error code from the server.
      */
-    let errorCode: StitchErrorCode
+    let errorCode: StitchServiceErrorCode
 
     /**
      * Private helper method which decodes the Stitch error from the body of an HTTP `Response` object. If the error
      * cannot be decoded, this is likely not an error from the Stitch server, and it will throw a
-     * `StitchError.unknownError`.
+     * `StitchError.serviceError` with a `.unknown` error code.
      */
     private static func handleRichError(forResponse response: Response,
                                         withBody body: Data) throws -> StitchErrorCodable {
-        // If this is not a JSON error, throw a `StitchError.unknownError` error with the body of the response as a
-        // UTF8 string as the message. If there is no body or it cannot be decoded as UTF8, throw an unknown error with
-        // no message.
+        // If this is not a JSON error, throw a `StitchError.serviceError` error with a `.unknown` error code and the
+        // body of the response as a UTF8 string as the message. If there is no body or it cannot be decoded as UTF8,
+        // throw an unknown error with no message.
         guard let contentType = response.headers[Headers.contentType.rawValue],
             contentType == ContentTypes.applicationJson.rawValue else {
                 guard let content = String.init(data: body, encoding: .utf8) else {
-                    throw StitchError.unknownError(withMessage: nil)
+                    throw StitchError.serviceError(withMessage: nil, withServiceErrorCode: .unknown)
                 }
 
-                throw StitchError.unknownError(withMessage: content)
+                throw StitchError.serviceError(withMessage: content, withServiceErrorCode: .unknown)
         }
 
         // Try decoding the JSON error as a `StitchErrorCodable`. If it can't be decoded, try throwing an unknown error
@@ -132,9 +139,10 @@ internal struct StitchErrorCodable: Codable {
         guard let error = try? JSONDecoder().decode(StitchErrorCodable.self,
                                                    from: body) else {
             guard let content = String.init(data: body, encoding: .utf8) else {
-                throw StitchError.unknownError(withMessage: nil)
+                throw StitchError.serviceError(withMessage: nil, withServiceErrorCode: .unknown)
             }
-            throw StitchError.unknownError(withMessage: content)
+
+            throw StitchError.serviceError(withMessage: content, withServiceErrorCode: .unknown)
         }
 
         // Return the decoded error
@@ -143,12 +151,12 @@ internal struct StitchErrorCodable: Codable {
 
     /**
      * Static utility method that accepts an HTTP `Response` object, and returns the `StitchError` representing the
-     * the error in the response. If the error cannot be recognized, this will return a `StitchError.unknownError`, or
-     * a `StitchError.emptyResponseError` if the response had no body.
+     * the error in the response. If the error cannot be recognized, this will return a `StitchError.serviceError` with
+     * the `.unknown` error code.
      */
     public static func handleError(inResponse response: Response) -> StitchError {
         guard let body = response.body else {
-            return StitchError.unknownError(withMessage: nil)
+            return StitchError.serviceError(withMessage: nil, withServiceErrorCode: .unknown)
         }
 
         var errorCodable: StitchErrorCodable!
@@ -157,13 +165,13 @@ internal struct StitchErrorCodable: Codable {
                                             withBody: body)
         } catch let err {
             // If handleRichError threw an error, return it as the error if it is a `StitchError`, or a
-            // `StitchError.unknownError` otherwise.
-            return err as? StitchError ?? StitchError.unknownError(withMessage: nil)
+            // `StitchError.serviceError` with an unknown code otherwise.
+            return err as? StitchError ?? StitchError.serviceError(withMessage: nil, withServiceErrorCode: .unknown)
         }
 
         // Return the StitchError.serviceError for the decoded error
         return StitchError.serviceError(withMessage: errorCodable.error,
-                                        withErrorCode: errorCodable.errorCode)
+                                        withServiceErrorCode: errorCodable.errorCode)
 
     }
 }

--- a/StitchCore/Sources/StitchCore/StitchError.swift
+++ b/StitchCore/Sources/StitchCore/StitchError.swift
@@ -1,32 +1,43 @@
 import Foundation
 
 /**
- * An enum representing an error related to Stitch.
+ * An enum representing an error returned from a server upon a completed request
+ *
+ * - important: A `StitchError` is only thrown if a request to a server has been completed. Transport-related errors,
+ *              such as being unable to connect to a server, are thrown by the underlying `Transport` that the Stitch
+ *              client is configured with, and will not be one of these errors. If no `Transport` is specified,
+ *              transport errors will be ones that are normally thrown by `URLSession.dataTask`.
  */
 public enum StitchError: Error {
     /**
-     * Indicates that the error is related specifically to Stitch, and has an error code defined in the
-     * `StitchErrorCode` enum.
+     * Indicates that the error was specifically from a Stitch server, with an error message and an error code
+     * defined in the `StitchErrorCode` enum.
      */
     case serviceError(withMessage: String, withErrorCode: StitchErrorCode)
 
     /**
-     * Indicates that the error was with the request made to the Stitch server. This could (but is not
-     * limited to) be due to the lack of connectivity or a request timeout.
+     * Indicates that the error type received from the server is not known. This may be due to a corrupted
+     * response, an error unrelated to Stitch (perhaps the server being contacted is not actually a Stitch server), or
+     * a new type of error that this version of the Stitch iOS SDK does not currently recognize. The error will be
+     * accompanied with a message unless the response was empty or could not be decoded as JSON or UTF-8 plaintext.
      */
-    case requestError(withMessage: String)
+    case unknownError(withMessage: String?)
 }
 
 /**
- * An enumeration indicating the errors that may occur when using a Stitch client. These errors would be thrown
+ * An enumeration indicating the errors that may occur when using a Stitch client. These errors are thrown
  * before the client performs any request against the server.
  */
 public enum StitchClientError: Error {
+    case loggedOutDuringRequest
+    case missingURL
     case mustAuthenticateFirst
+    case userNoLongerValid
 }
 
 /**
- * An enumeration of the types of errors that can come back from a completed Stitch request.
+ * An enumeration of the types of errors that can come back from a completed request to the Stitch server. These are
+ * the error codes as they are returned by the Stitch server in an error response.
  */
 public enum StitchErrorCode: String, Codable, Error {
     case missingAuthReq = "MissingAuthReq",
@@ -75,14 +86,12 @@ public enum StitchErrorCode: String, Codable, Error {
     notCallable = "FunctionNotCallable",
     userAlreadyConfirmed = "UserAlreadyConfirmed",
     userNotFound = "UserNotFound",
-    userDisabled = "UserDisabled",
-    unknown = "Unknown",
-    invalidURL = "Invalid URL"
+    userDisabled = "UserDisabled"
 }
 
 /**
- * `StitchErrorCodable` represents a Stitch error as it is returned by the Stitch server. The class contains a
- * static function that can return the appropriate `StitchError` or `StitchErrorCode` from an HTTP `Response`.
+ * `StitchErrorCodable` represents a Stitch error as it exists in the response to a request to the Stitch server. The
+ * class contains a static function that can return the appropriate `StitchError` from an HTTP `Response`.
  */
 internal struct StitchErrorCodable: Codable {
     private enum CodingKeys: String, CodingKey {
@@ -90,60 +99,71 @@ internal struct StitchErrorCodable: Codable {
     }
 
     /**
-     * The error message from the Stitch server.
+     * The error message from the server.
      */
-    let error: String?
+    let error: String
 
     /**
-     * The error code from the Stitch server.
+     * The error code from the server.
      */
-    let errorCode: StitchErrorCode?
+    let errorCode: StitchErrorCode
 
     /**
-     * Private helper method which decodes the Stitch error from the body of an HTTP `Response` object.
+     * Private helper method which decodes the Stitch error from the body of an HTTP `Response` object. If the error
+     * cannot be decoded, this is likely not an error from the Stitch server, and it will throw a
+     * `StitchError.unknownError`.
      */
     private static func handleRichError(forResponse response: Response,
                                         withBody body: Data) throws -> StitchErrorCodable {
+        // If this is not a JSON error, throw a `StitchError.unknownError` error with the body of the response as a
+        // UTF8 string as the message. If there is no body or it cannot be decoded as UTF8, throw an unknown error with
+        // no message.
         guard let contentType = response.headers[Headers.contentType.rawValue],
             contentType == ContentTypes.applicationJson.rawValue else {
                 guard let content = String.init(data: body, encoding: .utf8) else {
-                    throw StitchErrorCode.unknown
+                    throw StitchError.unknownError(withMessage: nil)
                 }
 
-                return StitchErrorCodable.init(error: content, errorCode: nil)
+                throw StitchError.unknownError(withMessage: content)
         }
 
+        // Try decoding the JSON error as a `StitchErrorCodable`. If it can't be decoded, try throwing an unknown error
+        // with the JSON as the message, or an empty message if the JSON can't be decoded as a UTF8 string.
         guard let error = try? JSONDecoder().decode(StitchErrorCodable.self,
                                                    from: body) else {
-            throw StitchErrorCode.unknown
+            guard let content = String.init(data: body, encoding: .utf8) else {
+                throw StitchError.unknownError(withMessage: nil)
+            }
+            throw StitchError.unknownError(withMessage: content)
         }
 
+        // Return the decoded error
         return error
     }
 
     /**
-     * Static utility method that accepts an HTTP `Response` object, and returns the `StitchError` contained within
-     * the response body. If there is no Stitch error in the body of the response, this will return
-     * `StitchErrorCode.unknown`.
+     * Static utility method that accepts an HTTP `Response` object, and returns the `StitchError` representing the
+     * the error in the response. If the error cannot be recognized, this will return a `StitchError.unknownError`, or
+     * a `StitchError.emptyResponseError` if the response had no body.
      */
-    public static func handleRequestError(response: Response) -> Error {
+    public static func handleError(inResponse response: Response) -> StitchError {
         guard let body = response.body else {
-            return StitchErrorCode.unknown
+            return StitchError.unknownError(withMessage: nil)
         }
 
-        var error: StitchErrorCodable!
+        var errorCodable: StitchErrorCodable!
         do {
-            error = try handleRichError(forResponse: response,
+            errorCodable = try handleRichError(forResponse: response,
                                             withBody: body)
         } catch let err {
-            return err
+            // If handleRichError threw an error, return it as the error if it is a `StitchError`, or a
+            // `StitchError.unknownError` otherwise.
+            return err as? StitchError ?? StitchError.unknownError(withMessage: nil)
         }
 
-        if response.statusCode >= 400 && response.statusCode < 600 {
-            return StitchError.serviceError(withMessage: error.error!,
-                                            withErrorCode: error.errorCode ?? .unknown)
-        }
+        // Return the StitchError.serviceError for the decoded error
+        return StitchError.serviceError(withMessage: errorCodable.error,
+                                        withErrorCode: errorCodable.errorCode)
 
-        return StitchError.requestError(withMessage: error.error!)
     }
 }

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/AccessTokenRefresherTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/AccessTokenRefresherTests.swift
@@ -51,7 +51,7 @@ class AccessTokenRefresherTests: XCTestCase {
         }
 
         // logout and relogin. setterAccessor should be accessed twice after this
-        try mockCoreAuth.logoutBlocking()
+        mockCoreAuth.logoutBlocking()
         _ = try mockCoreAuth.loginWithCredentialBlocking(withCredential: AnonymousCredential.init())
 
         // check refresh, which SHOULD trigger a refresh, and the setter

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
@@ -73,13 +73,15 @@ final class MockStitchRequestClient: StitchRequestClient {
 
     private func checkAuth(headers: [String: String]) throws {
         guard let authHeader = headers["Authorization"] else {
-            throw StitchError.requestError(withMessage: "Authorization header missing")
+            throw StitchError.serviceError(withMessage: "Invalid session authorization header",
+                                           withErrorCode: .invalidSession)
         }
 
         let headerComponents = authHeader.split(" ")
         guard headerComponents[0] == "Bearer",
               headerComponents.count == 2 else {
-            throw StitchError.requestError(withMessage: "Invalid authorization header")
+                throw StitchError.serviceError(withMessage: "Invalid session authorization header",
+                                               withErrorCode: .invalidSession)
         }
     }
 
@@ -97,7 +99,7 @@ final class MockStitchRequestClient: StitchRequestClient {
             try checkAuth(headers: stitchReq.headers)
             return try self.handleSessionRoute()
         default:
-            throw StitchError.requestError(withMessage: "Unknown mock path.")
+            throw StitchError.unknownError(withMessage: "404 page not found")
         }
     }
 
@@ -154,11 +156,6 @@ final class MockCoreStitchAuth: CoreStitchAuth<MockStitchUser> {
 }
 
 class CoreStitchAuthTests: StitchXCTestCase {
-    final class MockInvalidSessionError {
-        let error: String = StitchErrorCode.invalidSession.rawValue
-        let errorCode: StitchErrorCode = StitchErrorCode.invalidSession
-    }
-
     func testLoginWithCredentialBlocking() throws {
         let coreStitchAuth = try! MockCoreStitchAuth.init(requestClient: MockStitchRequestClient.init(),
                                                           authRoutes: appRoutes.authRoutes,

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
@@ -74,14 +74,14 @@ final class MockStitchRequestClient: StitchRequestClient {
     private func checkAuth(headers: [String: String]) throws {
         guard let authHeader = headers["Authorization"] else {
             throw StitchError.serviceError(withMessage: "Invalid session authorization header",
-                                           withErrorCode: .invalidSession)
+                                           withServiceErrorCode: .invalidSession)
         }
 
         let headerComponents = authHeader.split(" ")
         guard headerComponents[0] == "Bearer",
               headerComponents.count == 2 else {
                 throw StitchError.serviceError(withMessage: "Invalid session authorization header",
-                                               withErrorCode: .invalidSession)
+                                               withServiceErrorCode: .invalidSession)
         }
     }
 
@@ -99,7 +99,7 @@ final class MockStitchRequestClient: StitchRequestClient {
             try checkAuth(headers: stitchReq.headers)
             return try self.handleSessionRoute()
         default:
-            throw StitchError.unknownError(withMessage: "404 page not found")
+            throw StitchError.serviceError(withMessage: "404 page not found", withServiceErrorCode: .unknown)
         }
     }
 
@@ -231,7 +231,7 @@ class CoreStitchAuthTests: StitchXCTestCase {
                     oldLinkFunc
             }
             throw StitchError.serviceError(withMessage: "invalidSession",
-                                           withErrorCode: .invalidSession)
+                                           withServiceErrorCode: .invalidSession)
         }
 
         let user = try coreStitchAuth.loginWithCredentialBlocking(withCredential: AnonymousCredential.init())

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
@@ -204,7 +204,7 @@ class CoreStitchAuthTests: StitchXCTestCase {
         _ = try coreStitchAuth.loginWithCredentialBlocking(withCredential: AnonymousCredential.init())
         XCTAssert(coreStitchAuth.isLoggedIn)
 
-        try coreStitchAuth.logoutBlocking()
+        coreStitchAuth.logoutBlocking()
         XCTAssert(!coreStitchAuth.isLoggedIn)
     }
 

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/FoundationHTTPTransportTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/FoundationHTTPTransportTests.swift
@@ -42,9 +42,10 @@ class FoundationHTTPTransportTests: StitchXCTestCase {
         }
 
         XCTAssertThrowsError(
-            try transport.roundTrip(request: builder.build()),
-            StitchErrorCode.invalidURL.rawValue, { _ in }
-        )
+            try transport.roundTrip(request: builder.build())
+        ) { error in
+            XCTAssertEqual(error.localizedDescription, "unsupported URL")
+        }
 
         builder.url = "\(self.baseURL)\(self.getEndpoint)"
 
@@ -69,8 +70,9 @@ class FoundationHTTPTransportTests: StitchXCTestCase {
 
         builder.url = "http://localhost:9000/notreal"
         XCTAssertThrowsError(
-            try transport.roundTrip(request: builder.build()),
-            StitchErrorCode.unknown.rawValue, { _ in }
-        )
+            try transport.roundTrip(request: builder.build())
+        ) { error in
+            XCTAssertEqual(error.localizedDescription, "Could not connect to the server.")
+        }
     }
 }

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/StitchRequestClientTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/StitchRequestClientTests.swift
@@ -42,7 +42,7 @@ class StitchRequestClientTests: StitchXCTestCase {
             let stitchError = error as? StitchError
             XCTAssertNotNil(error as? StitchError)
             if let err = stitchError {
-                guard case .requestError = err else {
+                guard case .serviceError = err else {
                     XCTFail("doRequest returned an incorrect error type")
                     return
                 }

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/StitchRequestClientTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/StitchRequestClientTests.swift
@@ -38,7 +38,16 @@ class StitchRequestClientTests: StitchXCTestCase {
             $0.method = .get
         }
 
-        XCTAssertThrowsError(try stitchRequestClient.doRequest(builder.build()))
+        XCTAssertThrowsError(try stitchRequestClient.doRequest(builder.build())) { error in
+            let stitchError = error as? StitchError
+            XCTAssertNotNil(error as? StitchError)
+            if let err = stitchError {
+                guard case .requestError = err else {
+                    XCTFail("doRequest returned an incorrect error type")
+                    return
+                }
+            }
+        }
 
         builder.path = self.getEndpoint
 

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchAppClientConfigurationTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchAppClientConfigurationTests.swift
@@ -12,25 +12,33 @@ class StitchAppClientConfigurationBuilderTests: XCTestCase {
     func testStitchAppClientConfigurationBuilderInit() throws {
         var builder = StitchAppClientConfigurationBuilder { _ in }
 
-        XCTAssertThrowsError(try builder.build(),
-                             StitchAppClientConfigurationError.missingClientAppId.localizedDescription)
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(error as? StitchAppClientConfigurationError,
+                           StitchAppClientConfigurationError.missingClientAppId)
+        }
 
         builder.clientAppId = self.clientAppId
         builder.localAppVersion = self.localAppVersion
         builder.localAppName = self.localAppName
 
-        XCTAssertThrowsError(try builder.build(),
-                             StitchClientConfigurationError.missingBaseURL.localizedDescription)
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(error as? StitchClientConfigurationError,
+                           StitchClientConfigurationError.missingBaseURL)
+        }
 
         builder.baseURL = self.baseURL
 
-        XCTAssertThrowsError(try builder.build(),
-                             StitchClientConfigurationError.missingStorage.localizedDescription)
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(error as? StitchClientConfigurationError,
+                           StitchClientConfigurationError.missingStorage)
+        }
 
         builder.storage = self.storage
 
-        XCTAssertThrowsError(try builder.build(),
-                             StitchClientConfigurationError.missingTransport.localizedDescription)
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(error as? StitchClientConfigurationError,
+                           StitchClientConfigurationError.missingTransport)
+        }
 
         builder.transport = self.transport
 

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchClientConfigurationTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchClientConfigurationTests.swift
@@ -9,18 +9,24 @@ class StitchClientConfigurationTests: XCTestCase {
     func testStitchClientConfigurationBuilderImplInit() throws {
         var builder = StitchClientConfigurationBuilderImpl { _ in }
 
-        XCTAssertThrowsError(try builder.build(),
-                             StitchClientConfigurationError.missingBaseURL.localizedDescription)
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(error as? StitchClientConfigurationError,
+                           StitchClientConfigurationError.missingBaseURL)
+        }
 
         builder.baseURL = self.baseURL
 
-        XCTAssertThrowsError(try builder.build(),
-                             StitchClientConfigurationError.missingStorage.localizedDescription)
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(error as? StitchClientConfigurationError,
+                           StitchClientConfigurationError.missingStorage)
+        }
 
         builder.storage = self.storage
 
-        XCTAssertThrowsError(try builder.build(),
-                             StitchClientConfigurationError.missingTransport.localizedDescription)
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(error as? StitchClientConfigurationError,
+                           StitchClientConfigurationError.missingTransport)
+        }
 
         builder.transport = self.transport
 


### PR DESCRIPTION
I tried to refactor errors to be as consistent and cohesive as possible. It’s not too many changes, but I did think a lot about it as well as all of the edge cases. I’m happy to clarify anything

The gist of the change is that there now only three types of errors ever thrown by the SDK:
- `StitchClientError`: errors thrown before a request is made
- `StitchError`: errors thrown after a request is completed and a response is received
- Transport-specific errors: errors thrown while a request is being carried out (timeouts, could not reach server, etc.)

Main changes:
- StitchError now only represents errors that are from completed requests.
    - We now have `case unknownError` in `StitchError`
    - We no longer have `case requestError`. Instances were either replaced with an appropriate `StitchClientError`, or with an appropriate `unknownError` .
- StitchClientError now only represents errors that can occur before a request is ever made.
- Transports are responsible for throwing all errors that may be thrown while carrying out the request, and this is clarified in the comments.
- We no longer directly throw any error codes.
- `unknownError` and `invalidURL` were removed from `StitchErrorCode` as they aren’t actually Stitch error codes and are now their own appropriate cases in the other error enums.
- If the error returned from the server can’t be parsed as a JSON `ErrorCodable`, Stitch will return an unknown error with the response body text as the error message.

Drive-bys:
- XCTAssertThrowsError was not checking error messages as we thought, so I fixed all of our usages of it to actually verify that the correct error was being thrown
	- In the case of the roundTrip errors, they weren’t actually throwing Stitch errors at all, they were throwing errors specific to the transport, which is what we want
- Removed usages of `try! StitchCore.sync` and replaced with `objc_` stuff.