### PR TITLE
STITCH-1346 Add support for configuring data directory in StitchAppClient

### DIFF
--- a/StitchCore-iOS/StitchCore-iOS.xcodeproj/project.pbxproj
+++ b/StitchCore-iOS/StitchCore-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		111CCA05207C08A3002FEB4A /* StitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111CCA04207C08A3002FEB4A /* StitchTests.swift */; };
 		11297B1E205301C9001D0711 /* AuthProviderClientSupplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11297B1D205301C9001D0711 /* AuthProviderClientSupplier.swift */; };
 		11297B20205301D5001D0711 /* NamedAuthProviderClientSupplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11297B1F205301D5001D0711 /* NamedAuthProviderClientSupplier.swift */; };
 		112C5A822053334400463147 /* AnonymousAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112C5A812053334400463147 /* AnonymousAuthProvider.swift */; };
@@ -49,6 +50,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		111CCA04207C08A3002FEB4A /* StitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchTests.swift; sourceTree = "<group>"; };
 		11297B1D205301C9001D0711 /* AuthProviderClientSupplier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthProviderClientSupplier.swift; sourceTree = "<group>"; };
 		11297B1F205301D5001D0711 /* NamedAuthProviderClientSupplier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamedAuthProviderClientSupplier.swift; sourceTree = "<group>"; };
 		112C5A812053334400463147 /* AnonymousAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnonymousAuthProvider.swift; sourceTree = "<group>"; };
@@ -198,6 +200,7 @@
 			isa = PBXGroup;
 			children = (
 				11981A262062C8190074BB11 /* Internal */,
+				111CCA04207C08A3002FEB4A /* StitchTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -448,6 +451,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				111CCA05207C08A3002FEB4A /* StitchTests.swift in Sources */,
 				11981A242062C4B60074BB11 /* OperationDispatcherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
@@ -52,7 +52,7 @@ internal final class StitchAppClientImpl: StitchAppClient {
         self.dispatcher = OperationDispatcher.init(withDispatchQueue: queue)
         self.routes = StitchAppRoutes.init(clientAppId: config.clientAppId)
         self.info = StitchAppClientInfo(clientAppId: config.clientAppId,
-                                        dataDirectory: "", // STITCH-1346: make this non-empty
+                                        dataDirectory: config.dataDirectory, // STITCH-1346: make this non-empty
                                         localAppName: config.localAppName,
                                         localAppVersion: config.localAppVersion
         )

--- a/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
@@ -34,7 +34,7 @@ internal final class StitchAppClientImpl: StitchAppClient {
     /**
      * A `StitchAppClientInfo` describing the basic properties of this app client.
      */
-    private let info: StitchAppClientInfo
+    internal let info: StitchAppClientInfo
 
     /**
      * The API routes on the Stitch server to perform actions for this particular app.

--- a/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
@@ -52,7 +52,7 @@ internal final class StitchAppClientImpl: StitchAppClient {
         self.dispatcher = OperationDispatcher.init(withDispatchQueue: queue)
         self.routes = StitchAppRoutes.init(clientAppId: config.clientAppId)
         self.info = StitchAppClientInfo(clientAppId: config.clientAppId,
-                                        dataDirectory: config.dataDirectory, // STITCH-1346: make this non-empty
+                                        dataDirectory: config.dataDirectory,
                                         localAppName: config.localAppName,
                                         localAppVersion: config.localAppVersion
         )

--- a/StitchCore-iOS/StitchCore-iOS/Core/Stitch.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Stitch.swift
@@ -130,10 +130,12 @@ public class Stitch {
             finalConfigBuilder.storage = userDefaults
         }
 
-        // STITCH-1346:
-        //            if configBuilder.dataDirectory == nil {
-        //                finalConfigBuilder.dataDirectory = "/some/default/data/directory"
-        //            }
+        if configBuilder.dataDirectory == nil {
+            finalConfigBuilder.dataDirectory = try? FileManager.default.url(for: .applicationSupportDirectory,
+                                                                            in: .userDomainMask,
+                                                                            appropriateFor: nil,
+                                                                            create: true)
+        }
 
         if configBuilder.transport == nil {
             finalConfigBuilder.transport = FoundationHTTPTransport.init()

--- a/StitchCore-iOS/StitchCore_iOSTests/Core/StitchTests.swift
+++ b/StitchCore-iOS/StitchCore_iOSTests/Core/StitchTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import StitchCore_iOS
+
+class StitchTests: XCTestCase {
+
+    override func setUp() {
+        do {
+            try Stitch.initialize()
+            _ = try Stitch.initializeDefaultAppClient(
+                withConfigBuilder: StitchAppClientConfigurationBuilder.init({
+                    $0.clientAppId = "placeholder-app-id"
+                }))
+        } catch {
+            XCTFail("Failed to initialize MongoDB Stitch iOS SDK: \(error.localizedDescription)")
+        }
+    }
+
+    func testDataDirectoryInitialization() {
+        var client: StitchAppClient!
+        do {
+            try client = Stitch.getDefaultAppClient()
+        } catch {
+            XCTFail("No default app client initialized")
+        }
+
+        guard let clientImpl = client as? StitchAppClientImpl else {
+            XCTFail("App client is not a StitchAppClientImpl")
+            return
+        }
+
+        // Check that the default data directory configured by the SDK exists
+        XCTAssertTrue(FileManager.default.fileExists(atPath: clientImpl.info.dataDirectory.path))
+    }
+}

--- a/StitchCore/Sources/StitchCore/StitchAppClientConfiguration.swift
+++ b/StitchCore/Sources/StitchCore/StitchAppClientConfiguration.swift
@@ -38,7 +38,7 @@ public struct StitchAppClientConfigurationImpl: StitchAppClientConfiguration, Bu
     /**
      * The local directory in which Stitch can store any data (e.g. embedded MongoDB data directory).
      */
-    public let dataDirectory: URL?
+    public let dataDirectory: URL
 
     /**
      * The underlying storage for authentication info.
@@ -94,6 +94,10 @@ public struct StitchAppClientConfigurationImpl: StitchAppClientConfiguration, Bu
             throw StitchClientConfigurationError.missingBaseURL
         }
 
+        guard let dataDirectory = builder.dataDirectory else {
+            throw StitchClientConfigurationError.missingDataDirectory
+        }
+
         guard let storage = builder.storage else {
             throw StitchClientConfigurationError.missingStorage
         }
@@ -103,7 +107,7 @@ public struct StitchAppClientConfigurationImpl: StitchAppClientConfiguration, Bu
         }
 
         self.baseURL = baseURL
-        self.dataDirectory = builder.dataDirectory
+        self.dataDirectory = dataDirectory
         self.storage = storage
         self.transport = transport
     }

--- a/StitchCore/Sources/StitchCore/StitchAppClientConfiguration.swift
+++ b/StitchCore/Sources/StitchCore/StitchAppClientConfiguration.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /**
  * Properties representing the configuration of a client that communicate with a particular MongoDB Stitch application.
  */
@@ -32,6 +34,11 @@ public struct StitchAppClientConfigurationImpl: StitchAppClientConfiguration, Bu
      * The base URL of the Stitch server that the client will communicate with.
      */
     public let baseURL: String
+
+    /**
+     * The local directory in which Stitch can store any data (e.g. embedded MongoDB data directory).
+     */
+    public let dataDirectory: URL?
 
     /**
      * The underlying storage for authentication info.
@@ -96,6 +103,7 @@ public struct StitchAppClientConfigurationImpl: StitchAppClientConfiguration, Bu
         }
 
         self.baseURL = baseURL
+        self.dataDirectory = builder.dataDirectory
         self.storage = storage
         self.transport = transport
     }
@@ -122,6 +130,11 @@ public struct StitchAppClientConfigurationBuilder: StitchClientConfigurationBuil
      * The base URL of the Stitch server that the client will communicate with.
      */
     public var baseURL: String?
+
+    /**
+     * The local directory in which Stitch can store any data (e.g. embedded MongoDB data directory).
+     */
+    public var dataDirectory: URL?
 
     /**
      * The underlying storage for authentication info.

--- a/StitchCore/Sources/StitchCore/StitchAppClientInfo.swift
+++ b/StitchCore/Sources/StitchCore/StitchAppClientInfo.swift
@@ -8,7 +8,7 @@ public struct StitchAppClientInfo {
      * Initializes the `StitchAppClientInfo`.
      */
     public init(clientAppId: String,
-                dataDirectory: URL?,
+                dataDirectory: URL,
                 localAppName: String,
                 localAppVersion: String) {
         self.clientAppId = clientAppId
@@ -25,7 +25,7 @@ public struct StitchAppClientInfo {
     /**
      * The local directory in which Stitch can store any data (e.g. MongoDB Mobile data directory).
      */
-    public let dataDirectory: URL?
+    public let dataDirectory: URL
 
     /**
      * The name of the local application.

--- a/StitchCore/Sources/StitchCore/StitchAppClientInfo.swift
+++ b/StitchCore/Sources/StitchCore/StitchAppClientInfo.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /**
  * A struct providing basic information about a Stitch app client.
  */
@@ -6,7 +8,7 @@ public struct StitchAppClientInfo {
      * Initializes the `StitchAppClientInfo`.
      */
     public init(clientAppId: String,
-                dataDirectory: String,
+                dataDirectory: URL?,
                 localAppName: String,
                 localAppVersion: String) {
         self.clientAppId = clientAppId
@@ -23,7 +25,7 @@ public struct StitchAppClientInfo {
     /**
      * The local directory in which Stitch can store any data (e.g. MongoDB Mobile data directory).
      */
-    public let dataDirectory: String
+    public let dataDirectory: URL?
 
     /**
      * The name of the local application.

--- a/StitchCore/Sources/StitchCore/StitchClientConfiguration.swift
+++ b/StitchCore/Sources/StitchCore/StitchClientConfiguration.swift
@@ -13,7 +13,7 @@ public protocol StitchClientConfiguration {
     /**
      * The local directory in which Stitch can store any data (e.g. embedded MongoDB data directory).
      */
-    var dataDirectory: URL? { get }
+    var dataDirectory: URL { get }
 
     /**
      * The underlying storage for persisting authentication and app state.
@@ -44,7 +44,7 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
     /**
      * The local directory in which Stitch can store any data (e.g. embedded MongoDB data directory).
      */
-    public let dataDirectory: URL?
+    public let dataDirectory: URL
 
     /**
      * The underlying storage for authentication info.
@@ -66,6 +66,10 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
             throw StitchClientConfigurationError.missingBaseURL
         }
 
+        guard let dataDirectory = builder.dataDirectory else {
+            throw StitchClientConfigurationError.missingDataDirectory
+        }
+
         guard let storage = builder.storage else {
             throw StitchClientConfigurationError.missingStorage
         }
@@ -75,7 +79,7 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
         }
 
         self.baseURL = baseURL
-        self.dataDirectory = builder.dataDirectory
+        self.dataDirectory = dataDirectory
         self.storage = storage
         self.transport = transport
     }
@@ -87,6 +91,7 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
  */
 public enum StitchClientConfigurationError: Error {
     case missingBaseURL
+    case missingDataDirectory
     case missingStorage
     case missingTransport
 }

--- a/StitchCore/Sources/StitchCore/StitchClientConfiguration.swift
+++ b/StitchCore/Sources/StitchCore/StitchClientConfiguration.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /**
  * :nodoc:
  * Properties representing the configuration of a client that can communicate with MongoDB Stitch.
@@ -7,6 +9,11 @@ public protocol StitchClientConfiguration {
      * The base URL of the Stitch server that the client will communicate with.
      */
     var baseURL: String { get }
+
+    /**
+     * The local directory in which Stitch can store any data (e.g. embedded MongoDB data directory).
+     */
+    var dataDirectory: URL? { get }
 
     /**
      * The underlying storage for persisting authentication and app state.
@@ -33,6 +40,11 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
      * The base URL of the Stitch server that the client will communicate with.
      */
     public let baseURL: String
+
+    /**
+     * The local directory in which Stitch can store any data (e.g. embedded MongoDB data directory).
+     */
+    public let dataDirectory: URL?
 
     /**
      * The underlying storage for authentication info.
@@ -63,6 +75,7 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
         }
 
         self.baseURL = baseURL
+        self.dataDirectory = builder.dataDirectory
         self.storage = storage
         self.transport = transport
     }
@@ -89,6 +102,11 @@ public protocol StitchClientConfigurationBuilder {
     var baseURL: String? { get }
 
     /**
+     * The local directory in which Stitch can store any data (e.g. embedded MongoDB data directory).
+     */
+    var dataDirectory: URL? { get }
+
+    /**
      * The underlying storage for authentication info.
      */
     var storage: Storage? { get }
@@ -108,6 +126,11 @@ public struct StitchClientConfigurationBuilderImpl: StitchClientConfigurationBui
      * The base URL of the Stitch server that the client will communicate with.
      */
     public var baseURL: String?
+
+    /**
+     * The local directory in which Stitch can store any data (e.g. embedded MongoDB data directory).
+     */
+    public var dataDirectory: URL?
 
     /**
      * The underlying storage for authentication info.

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchAppClientInfoTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchAppClientInfoTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class StitchAppClientInfoTests: XCTestCase {
     private let clientAppId = "foo"
-    private let dataDirectory = "bar"
+    private let dataDirectory = URL.init(string: "bar")
     private let localAppName = "baz"
     private let localAppVersion = "qux"
 


### PR DESCRIPTION
Adds support for configuring an optional data directory for a Stitch app client. On iOS, this is set by default to the "Application Support" directory in the app's sandboxed filesystem. This was selected because of this description in the Apple docs:

"In general, this directory includes files that the app uses to run but that should remain hidden from the user. This directory can also include data files, configuration files, templates and modified versions of resources loaded from the app bundle."

The "Application Support" directory is also backed up by default.