### PR TITLE
STITCH-1316 Handle Transport timeouts

### DIFF
--- a/StitchCore-iOS/StitchCore-iOS.xcodeproj/project.pbxproj
+++ b/StitchCore-iOS/StitchCore-iOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		11981A112061B9D50074BB11 /* OperationDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11981A102061B9D50074BB11 /* OperationDispatcher.swift */; };
 		11981A1E2062C4AA0074BB11 /* StitchCore_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4902C678205006C800E53674 /* StitchCore_iOS.framework */; };
 		11981A242062C4B60074BB11 /* OperationDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11981A132062C12D0074BB11 /* OperationDispatcherTests.swift */; };
+		11B1840520A37ECA00B62ABB /* StitchAppClientIntegrationAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11B1840420A37ECA00B62ABB /* StitchAppClientIntegrationAuthTests.swift */; };
 		11C587D82056D06000B34DD1 /* CustomAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C587D72056D06000B34DD1 /* CustomAuthProvider.swift */; };
 		11C587DA2056D28F00B34DD1 /* FacebookAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C587D92056D28F00B34DD1 /* FacebookAuthProvider.swift */; };
 		11C587DC2056D40B00B34DD1 /* GoogleAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C587DB2056D40B00B34DD1 /* GoogleAuthProvider.swift */; };
@@ -66,6 +67,7 @@
 		11981A132062C12D0074BB11 /* OperationDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationDispatcherTests.swift; sourceTree = "<group>"; };
 		11981A192062C4AA0074BB11 /* StitchCore_iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StitchCore_iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		11981A1D2062C4AA0074BB11 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		11B1840420A37ECA00B62ABB /* StitchAppClientIntegrationAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchAppClientIntegrationAuthTests.swift; sourceTree = "<group>"; };
 		11C587D72056D06000B34DD1 /* CustomAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAuthProvider.swift; sourceTree = "<group>"; };
 		11C587D92056D28F00B34DD1 /* FacebookAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FacebookAuthProvider.swift; sourceTree = "<group>"; };
 		11C587DB2056D40B00B34DD1 /* GoogleAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAuthProvider.swift; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 				11981A262062C8190074BB11 /* Internal */,
 				111CCA04207C08A3002FEB4A /* StitchTests.swift */,
 				116168B5208A6B1000967A7E /* StitchAppClientIntegrationTests.swift */,
+				11B1840420A37ECA00B62ABB /* StitchAppClientIntegrationAuthTests.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -487,6 +490,7 @@
 			files = (
 				116168B9208A6B3200967A7E /* TestHarness.swift in Sources */,
 				112F050F209149B500DDB147 /* StitchIntegrationTestCase.swift in Sources */,
+				11B1840520A37ECA00B62ABB /* StitchAppClientIntegrationAuthTests.swift in Sources */,
 				111CCA05207C08A3002FEB4A /* StitchTests.swift in Sources */,
 				116168B6208A6B1000967A7E /* StitchAppClientIntegrationTests.swift in Sources */,
 				11981A242062C4B60074BB11 /* OperationDispatcherTests.swift in Sources */,

--- a/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
@@ -58,12 +58,14 @@ internal final class StitchAppClientImpl: StitchAppClient {
         )
 
         let internalAuth =
-            try StitchAuthImpl.init(requestClient: StitchRequestClientImpl.init(baseURL: config.baseURL,
-                                                                                transport: config.transport),
-                                     authRoutes: self.routes.authRoutes,
-                                     storage: config.storage,
-                                     dispatcher: self.dispatcher,
-                                     appInfo: self.info)
+            try StitchAuthImpl.init(
+                requestClient: StitchRequestClientImpl.init(baseURL: config.baseURL,
+                                                            transport: config.transport,
+                                                            transportTimeout: config.transportTimeout),
+                authRoutes: self.routes.authRoutes,
+                storage: config.storage,
+                dispatcher: self.dispatcher,
+                appInfo: self.info)
 
         self._auth = internalAuth
         self.coreClient = CoreStitchAppClient.init(authRequestClient: internalAuth, routes: routes)

--- a/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
@@ -61,7 +61,7 @@ internal final class StitchAppClientImpl: StitchAppClient {
             try StitchAuthImpl.init(
                 requestClient: StitchRequestClientImpl.init(baseURL: config.baseURL,
                                                             transport: config.transport,
-                                                            transportTimeout: config.transportTimeout),
+                                                            defaultRequestTimeout: config.defaultRequestTimeout),
                 authRoutes: self.routes.authRoutes,
                 storage: config.storage,
                 dispatcher: self.dispatcher,
@@ -131,6 +131,33 @@ internal final class StitchAppClientImpl: StitchAppClient {
                              _ completionHandler: @escaping (Any?, Error?) -> Void) {
         dispatcher.run(withCompletionHandler: completionHandler) {
             return try self.coreClient.callFunctionInternal(withName: name, withArgs: args)
+        }
+    }
+
+    /**
+     * Calls the MongoDB Stitch function with the provided name and arguments, as well as with a specified timeout. Use
+     * this for functions that may run longer than the default 15 second timeout.
+     *
+     * - parameters:
+     *     - withName: The name of the Stitch function to be called.
+     *     - withArgs: The `BSONArray` of arguments to be provided to the function.
+     *     - withRequestTimeout: The number of seconds the client should wait for a response from the server before
+     *                           failing with an error.
+     *     - completionHandler: The completion handler to call when the function call is complete.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     *     - result: The result of the function call as an `Any`, or `nil` if the function call failed.
+     *     - error: An error object that indicates why the function call failed, or `nil` if the function call was
+     *              successful.
+     *
+     */
+    public func callFunction(withName name: String,
+                             withArgs args: BSONArray,
+                             withRequestTimeout requestTimeout: TimeInterval,
+                             _ completionHandler: @escaping (Any?, Error?) -> Void) {
+        dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.coreClient.callFunctionInternal(withName: name,
+                                                            withArgs: args,
+                                                            withRequestTimeout: requestTimeout)
         }
     }
 }

--- a/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Internal/StitchAppClientImpl.swift
@@ -136,7 +136,7 @@ internal final class StitchAppClientImpl: StitchAppClient {
 
     /**
      * Calls the MongoDB Stitch function with the provided name and arguments, as well as with a specified timeout. Use
-     * this for functions that may run longer than the default 15 second timeout.
+     * this for functions that may run longer than the client-wide default timeout (15 seconds by default).
      *
      * - parameters:
      *     - withName: The name of the Stitch function to be called.

--- a/StitchCore-iOS/StitchCore-iOS/Core/Stitch.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/Stitch.swift
@@ -16,7 +16,7 @@ public class Stitch {
 
     private static let defaultBaseUrl: String = "https://stitch.mongodb.com"
     private static let userDefaultsName: String = "com.mongodb.stitch.sdk.UserDefaults"
-    private static let defaultTransportTimeout: TimeInterval = 15.0
+    private static let defaultDefaultRequestTimeout: TimeInterval = 15.0
 
     private static var appClients: [String: StitchAppClientImpl] = [:]
 
@@ -122,8 +122,8 @@ public class Stitch {
             finalConfigBuilder.transport = FoundationHTTPTransport.init()
         }
 
-        if configBuilder.transportTimeout == nil {
-            finalConfigBuilder.transportTimeout = defaultTransportTimeout
+        if configBuilder.defaultRequestTimeout == nil {
+            finalConfigBuilder.defaultRequestTimeout = defaultDefaultRequestTimeout
         }
 
         if configBuilder.baseURL == nil {

--- a/StitchCore-iOS/StitchCore-iOS/Core/StitchAppClient.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/StitchAppClient.swift
@@ -65,7 +65,7 @@ public protocol StitchAppClient {
 
     /**
      * Calls the MongoDB Stitch function with the provided name and arguments, as well as with a specified timeout. Use
-     * this for functions that may run longer than the default 15 second timeout.
+     * this for functions that may run longer than the client-wide default timeout (15 seconds by default).
      *
      * - parameters:
      *     - withName: The name of the Stitch function to be called.

--- a/StitchCore-iOS/StitchCore-iOS/Core/StitchAppClient.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Core/StitchAppClient.swift
@@ -1,4 +1,5 @@
 import ExtendedJSON
+import StitchCore
 
 /**
  * The fundamental set of methods for communicating with a MongoDB Stitch application.
@@ -61,6 +62,24 @@ public protocol StitchAppClient {
      *
      */
     func callFunction(withName name: String, withArgs args: BSONArray, _ completionHandler: @escaping (_ result: Any?, _ error: Error?) -> Void)
+
+    /**
+     * Calls the MongoDB Stitch function with the provided name and arguments, as well as with a specified timeout. Use
+     * this for functions that may run longer than the default 15 second timeout.
+     *
+     * - parameters:
+     *     - withName: The name of the Stitch function to be called.
+     *     - withArgs: The `BSONArray` of arguments to be provided to the function.
+     *     - withRequestTimeout: The number of seconds the client should wait for a response from the server before
+     *                           failing with an error.
+     *     - completionHandler: The completion handler to call when the function call is complete.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     *     - result: The result of the function call as an `Any`, or `nil` if the function call failed.
+     *     - error: An error object that indicates why the function call failed, or `nil` if the function call was
+     *              successful.
+     *
+     */
+    func callFunction(withName name: String, withArgs args: BSONArray, withRequestTimeout requestTimeout: TimeInterval, _ completionHandler: @escaping (_ result: Any?, _ error: Error?) -> Void)
 
     // swiftlint:enable line_length
 }

--- a/StitchCore-iOS/StitchCore-iOS/Services/Internal/StitchService.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Services/Internal/StitchService.swift
@@ -1,4 +1,5 @@
 import ExtendedJSON
+import Foundation
 
 /**
  * A protocol representing a MongoDB Stitch service, with methods for executing functions on that service.
@@ -23,6 +24,24 @@ public protocol StitchService {
      *
      */
     func callFunction(withName name: String, withArgs args: BSONArray, _ completionHandler: @escaping (_ result: Any?, _ error: Error?) -> Void)
+
+    /**
+     * Calls the function for this service with the provided name and arguments, as well as with a specified timeout.
+     * Use this for functions that may run longer than the client-wide default timeout (15 seconds by default).
+     *
+     * - parameters:
+     *     - withName: The name of the function to be called.
+     *     - withArgs: The `BSONArray` of arguments to be provided to the function.
+     *     - withRequestTimeout: The number of seconds the client should wait for a response from the server before
+     *                           failing with an error.
+     *     - completionHandler: The completion handler to call when the function call is complete.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     *     - result: The result of the function call as an `Any`, or `nil` if the function call failed.
+     *     - error: An error object that indicates why the function call failed, or `nil` if the function call was
+     *              successful.
+     *
+     */
+    func callFunction(withName name: String, withArgs args: BSONArray, withRequestTimeout requestTimeout: TimeInterval, _ completionHandler: @escaping (_ result: Any?, _ error: Error?) -> Void)
 
     // swiftlint:enable line_length
 }

--- a/StitchCore-iOS/StitchCore-iOS/Services/Internal/StitchServiceImpl.swift
+++ b/StitchCore-iOS/StitchCore-iOS/Services/Internal/StitchServiceImpl.swift
@@ -44,4 +44,29 @@ internal final class StitchServiceImpl: CoreStitchService, StitchService {
             return try self.callFunctionInternal(withName: name, withArgs: args)
         }
     }
+
+    /**
+     * Calls the function for this service with the provided name and arguments, as well as with a specified timeout.
+     * Use this for functions that may run longer than the client-wide default timeout (15 seconds by default).
+     *
+     * - parameters:
+     *     - withName: The name of the function to be called.
+     *     - withArgs: The `BSONArray` of arguments to be provided to the function.
+     *     - withRequestTimeout: The number of seconds the client should wait for a response from the server before
+     *                           failing with an error.
+     *     - completionHandler: The completion handler to call when the function call is complete.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     *     - result: The result of the function call as an `Any`, or `nil` if the function call failed.
+     *     - error: An error object that indicates why the function call failed, or `nil` if the function call was
+     *              successful.
+     *
+     */
+    public func callFunction(withName name: String,
+                             withArgs args: BSONArray,
+                             withRequestTimeout requestTimeout: TimeInterval,
+                             _ completionHandler: @escaping (Any?, Error?) -> Void) {
+        dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.callFunctionInternal(withName: name, withArgs: args, withRequestTimeout: requestTimeout)
+        }
+    }
 }

--- a/StitchCore-iOS/StitchCore_iOSTests/Core/StitchAppClientIntegrationAuthTests.swift
+++ b/StitchCore-iOS/StitchCore_iOSTests/Core/StitchAppClientIntegrationAuthTests.swift
@@ -1,0 +1,254 @@
+import Foundation
+import XCTest
+import JWT
+import StitchCore
+import ExtendedJSON
+@testable import StitchCore_iOS
+
+class StitchAppClientIntegrationAuthTests: StitchIntegrationTestCase {
+    private func registerAndLogin(email: String = email,
+                                  password: String = pass,
+                                  _ completionHandler: @escaping (StitchUser) -> Void) {
+        let emailPassClient = self.stitchAppClient.auth.providerClient(
+            forProvider: UserPasswordAuthProvider.clientSupplier
+        )
+        emailPassClient.register(withEmail: email, withPassword: password) { _ in
+            let conf = try? self.harness.app.userRegistrations.sendConfirmation(toEmail: email)
+            guard let safeConf = conf else { XCTFail("could not retrieve email confirmation token"); return }
+            emailPassClient.confirmUser(withToken: safeConf.token,
+                                        withTokenId: safeConf.tokenId
+            ) { _ in
+                self.stitchAppClient.auth.login(
+                    withCredential: emailPassClient.credential(forUsername: email, forPassword: password)
+                ) { user, _ in
+                    guard let user = user else {
+                        XCTFail("Failed to log in with username/password provider")
+                        return
+                    }
+                    completionHandler(user)
+                }
+            }
+        }
+    }
+
+    private func logoutAndCheckStorage() {
+        let exp = expectation(description: "logged out")
+        self.stitchAppClient.auth.logout { _ in
+            self.verifyBasicAuthStorageInfo(loggedIn: false)
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: defaultTimeoutSeconds)
+    }
+
+    private func verifyBasicAuthStorageInfo(loggedIn: Bool,
+                                            expectedProviderType: StitchProviderType? = nil) {
+        XCTAssertEqual(self.stitchAppClient.auth.isLoggedIn, loggedIn)
+        if loggedIn {
+            guard
+                let user = self.stitchAppClient.auth.currentUser,
+                let providerType = expectedProviderType else {
+                    XCTFail("must provide expected provider type to verify storage")
+                    return
+            }
+            XCTAssertEqual(user.loggedInProviderType, providerType)
+        } else {
+            XCTAssertNil(self.stitchAppClient.auth.currentUser)
+        }
+    }
+
+    func testAnonymousLogin() throws {
+        let exp = expectation(description: "logged in anonymously")
+
+        let anonAuthClient = stitchAppClient.auth.providerClient(forProvider: AnonymousAuthProvider.clientSupplier)
+        stitchAppClient.auth.login(withCredential: anonAuthClient.credential) { user, _ in
+            XCTAssertNotNil(user)
+            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.anonymous)
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: defaultTimeoutSeconds)
+    }
+
+    func testUserProfile() throws {
+        let exp = expectation(description: "verified profile information")
+
+        let anonAuthClient = stitchAppClient.auth.providerClient(forProvider: AnonymousAuthProvider.clientSupplier)
+        stitchAppClient.auth.login(withCredential: anonAuthClient.credential) { user, _ in
+            XCTAssertNotNil(user)
+            XCTAssertEqual(user!.profile.userType, "normal")
+            XCTAssertEqual(user!.profile.identities[0].providerType, "anon-user")
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: defaultTimeoutSeconds)
+    }
+
+    func testCustomLogin() throws {
+        let jwt = JWT.encode(Algorithm.hs256(
+            "abcdefghijklmnopqrstuvwxyz1234567890".data(using: .utf8)!)
+        ) { (builder: ClaimSetBuilder) in
+            builder.audience = harness.testApp?.clientAppId
+            builder.notBefore = Date()
+            builder.issuedAt = Date()
+            builder.expiration = Date().addingTimeInterval(TimeInterval(60 * 5))
+            builder["sub"] = "uniqueUserID"
+            builder["stitch_meta"] = [
+                "email": "name@example.com",
+                "name": "Joe Bloggs",
+                "picture_url": "https://goo.gl/xqR6Jd"
+            ]
+        }
+
+        _ = self.harness.addDefaultCustomTokenProvider()
+        let customAuthClient = self.stitchAppClient.auth.providerClient(forProvider:
+            CustomAuthProvider.clientSupplier
+        )
+
+        let exp1 = expectation(description: "first custom login")
+        var userId: String!
+        self.stitchAppClient.auth.login(withCredential:
+            customAuthClient.credential(withToken: jwt)
+        ) { user, _ in
+            XCTAssertNotNil(user)
+
+            userId = user!.id
+
+            // Verify profile information in metadata
+            let profile = user!.profile
+            XCTAssertEqual(profile.email, "name@example.com")
+            XCTAssertEqual(profile.name, "Joe Bloggs")
+            XCTAssertEqual(profile.pictureURL, "https://goo.gl/xqR6Jd")
+
+            exp1.fulfill()
+        }
+        wait(for: [exp1], timeout: defaultTimeoutSeconds)
+
+        let exp2 = expectation(description: "second custom login")
+        stitchAppClient.auth.logout { _ in
+            self.stitchAppClient.auth.login(withCredential:
+                customAuthClient.credential(withToken: jwt)
+            ) { user, _ in
+                XCTAssertNotNil(user)
+
+                // Ensure that the same user logs in if the token has the same unique user ID.
+                XCTAssertEqual(userId, user!.id)
+
+                exp2.fulfill()
+            }
+        }
+        wait(for: [exp2], timeout: defaultTimeoutSeconds)
+    }
+
+    func testMultipleLoginSemantics() throws {
+        // check storage
+        verifyBasicAuthStorageInfo(loggedIn: false)
+
+        // login anonymously
+        let exp1 = expectation(description: "log in anonymously")
+        var anonUserId: String!
+        self.stitchAppClient.auth.login(
+            withCredential: self.stitchAppClient.auth.providerClient(forProvider:
+                AnonymousAuthProvider.clientSupplier).credential
+        ) { (user: StitchUser?, _) in
+            XCTAssertNotNil(user)
+            anonUserId = user!.id
+
+            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.anonymous)
+            exp1.fulfill()
+        }
+        wait(for: [exp1], timeout: defaultTimeoutSeconds)
+
+        // login anonymously again
+        let exp2 = expectation(description: "log in anonymously again")
+
+        self.stitchAppClient.auth.login(
+            withCredential: self.stitchAppClient.auth.providerClient(forProvider:
+                AnonymousAuthProvider.clientSupplier).credential
+        ) { (user: StitchUser?, _) in
+            XCTAssertNotNil(user)
+
+            // make sure user ID is the name
+            XCTAssertEqual(anonUserId, user!.id)
+
+            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.anonymous)
+            exp2.fulfill()
+        }
+        wait(for: [exp2], timeout: defaultTimeoutSeconds)
+
+        let exp3 = expectation(description: "logged in as email/password user")
+        var emailUserId: String!
+        self.registerAndLogin(email: "test1@10gen.com", password: "hunter1") { user in
+            let nextUserId = user.id
+            XCTAssertNotEqual(anonUserId, nextUserId)
+            emailUserId = nextUserId
+
+            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.userPassword)
+            exp3.fulfill()
+        }
+        wait(for: [exp3], timeout: defaultTimeoutSeconds)
+
+        let exp4 = expectation(description: "logged in as second email/password user")
+        self.registerAndLogin(email: "test2@10gen.com", password: "hunter2") { user in
+            let nextUserId = user.id
+            XCTAssertNotEqual(emailUserId, nextUserId)
+
+            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.userPassword)
+            exp4.fulfill()
+        }
+        wait(for: [exp4], timeout: defaultTimeoutSeconds)
+
+        logoutAndCheckStorage()
+    }
+
+    func testIdentityLinking() throws {
+        let exp1 = expectation(description: "logged in with anonymous provider")
+        var anonUser: StitchUser!
+        self.stitchAppClient.auth.login(
+            withCredential: self.stitchAppClient.auth.providerClient(
+                forProvider: AnonymousAuthProvider.clientSupplier).credential
+        ) { (user, _) in
+            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.anonymous)
+            anonUser = user
+            exp1.fulfill()
+        }
+        wait(for: [exp1], timeout: defaultTimeoutSeconds)
+
+        let userPassClient = self.stitchAppClient.auth.providerClient(
+            forProvider: UserPasswordAuthProvider.clientSupplier
+        )
+
+        let exp2 = expectation(description: "new email/password identity is created and confirmed")
+        userPassClient.register(withEmail: "stitch@10gen.com", withPassword: "password") { error in
+            XCTAssertNil(error)
+            exp2.fulfill()
+        }
+        wait(for: [exp2], timeout: defaultTimeoutSeconds)
+
+        let exp3 = expectation(description: "new email/password identity is confirmed")
+        let conf = try? self.harness.app.userRegistrations.sendConfirmation(toEmail: "stitch@10gen.com")
+        guard let safeConf = conf else {
+            XCTFail("could not retrieve email confirmation token")
+            return
+        }
+
+        userPassClient.confirmUser(withToken: safeConf.token, withTokenId: safeConf.tokenId) { error in
+            XCTAssertNil(error)
+            exp3.fulfill()
+        }
+        wait(for: [exp3], timeout: defaultTimeoutSeconds)
+
+        let exp4 = expectation(description: "original account linked with new email/password identity")
+        anonUser.link(
+            withCredential: userPassClient.credential(forUsername: "stitch@10gen.com", forPassword: "password")
+        ) { linkedUser, _ in
+            XCTAssertNotNil(linkedUser)
+            XCTAssertEqual(anonUser.id, linkedUser!.id)
+            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.userPassword)
+            XCTAssertEqual(linkedUser?.profile.identities.count, 2)
+            exp4.fulfill()
+        }
+        wait(for: [exp4], timeout: defaultTimeoutSeconds)
+
+        logoutAndCheckStorage()
+    }
+}

--- a/StitchCore-iOS/StitchCore_iOSTests/Core/StitchAppClientIntegrationTests.swift
+++ b/StitchCore-iOS/StitchCore_iOSTests/Core/StitchAppClientIntegrationTests.swift
@@ -6,252 +6,6 @@ import ExtendedJSON
 @testable import StitchCore_iOS
 
 class StitchAppClientIntegrationTests: StitchIntegrationTestCase {
-    private func registerAndLogin(email: String = email,
-                                  password: String = pass,
-                                  _ completionHandler: @escaping (StitchUser) -> Void) {
-        let emailPassClient = self.stitchAppClient.auth.providerClient(
-            forProvider: UserPasswordAuthProvider.clientSupplier
-        )
-        emailPassClient.register(withEmail: email, withPassword: password) { _ in
-            let conf = try? self.harness.app.userRegistrations.sendConfirmation(toEmail: email)
-            guard let safeConf = conf else { XCTFail("could not retrieve email confirmation token"); return }
-            emailPassClient.confirmUser(withToken: safeConf.token,
-                                        withTokenId: safeConf.tokenId
-                ) { _ in
-                self.stitchAppClient.auth.login(
-                    withCredential: emailPassClient.credential(forUsername: email, forPassword: password)
-                ) { user, _ in
-                    guard let user = user else {
-                        XCTFail("Failed to log in with username/password provider")
-                        return
-                    }
-                    completionHandler(user)
-                }
-            }
-        }
-    }
-
-    private func logoutAndCheckStorage() {
-        let exp = expectation(description: "logged out")
-        self.stitchAppClient.auth.logout { _ in
-            self.verifyBasicAuthStorageInfo(loggedIn: false)
-            exp.fulfill()
-        }
-        wait(for: [exp], timeout: defaultTimeoutSeconds)
-    }
-
-    private func verifyBasicAuthStorageInfo(loggedIn: Bool,
-                                            expectedProviderType: StitchProviderType? = nil) {
-        XCTAssertEqual(self.stitchAppClient.auth.isLoggedIn, loggedIn)
-        if loggedIn {
-            guard
-                let user = self.stitchAppClient.auth.currentUser,
-                let providerType = expectedProviderType else {
-                XCTFail("must provide expected provider type to verify storage")
-                    return
-            }
-            XCTAssertEqual(user.loggedInProviderType, providerType)
-        } else {
-            XCTAssertNil(self.stitchAppClient.auth.currentUser)
-        }
-    }
-
-    func testAnonymousLogin() throws {
-        let exp = expectation(description: "logged in anonymously")
-
-        let anonAuthClient = stitchAppClient.auth.providerClient(forProvider: AnonymousAuthProvider.clientSupplier)
-        stitchAppClient.auth.login(withCredential: anonAuthClient.credential) { user, _ in
-            XCTAssertNotNil(user)
-            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.anonymous)
-            exp.fulfill()
-        }
-
-        wait(for: [exp], timeout: defaultTimeoutSeconds)
-    }
-
-    func testUserProfile() throws {
-        let exp = expectation(description: "verified profile information")
-
-        let anonAuthClient = stitchAppClient.auth.providerClient(forProvider: AnonymousAuthProvider.clientSupplier)
-        stitchAppClient.auth.login(withCredential: anonAuthClient.credential) { user, _ in
-            XCTAssertNotNil(user)
-            XCTAssertEqual(user!.profile.userType, "normal")
-            XCTAssertEqual(user!.profile.identities[0].providerType, "anon-user")
-            exp.fulfill()
-        }
-
-        wait(for: [exp], timeout: defaultTimeoutSeconds)
-    }
-
-    func testCustomLogin() throws {
-        let jwt = JWT.encode(Algorithm.hs256(
-            "abcdefghijklmnopqrstuvwxyz1234567890".data(using: .utf8)!)
-        ) { (builder: ClaimSetBuilder) in
-            builder.audience = harness.testApp?.clientAppId
-            builder.notBefore = Date()
-            builder.issuedAt = Date()
-            builder.expiration = Date().addingTimeInterval(TimeInterval(60 * 5))
-            builder["sub"] = "uniqueUserID"
-            builder["stitch_meta"] = [
-                "email": "name@example.com",
-                "name": "Joe Bloggs",
-                "picture_url": "https://goo.gl/xqR6Jd"
-            ]
-        }
-
-        _ = self.harness.addDefaultCustomTokenProvider()
-        let customAuthClient = self.stitchAppClient.auth.providerClient(forProvider:
-            CustomAuthProvider.clientSupplier
-        )
-
-        let exp1 = expectation(description: "first custom login")
-        var userId: String!
-        self.stitchAppClient.auth.login(withCredential:
-            customAuthClient.credential(withToken: jwt)
-        ) { user, _ in
-            XCTAssertNotNil(user)
-
-            userId = user!.id
-
-            // Verify profile information in metadata
-            let profile = user!.profile
-            XCTAssertEqual(profile.email, "name@example.com")
-            XCTAssertEqual(profile.name, "Joe Bloggs")
-            XCTAssertEqual(profile.pictureURL, "https://goo.gl/xqR6Jd")
-
-            exp1.fulfill()
-        }
-        wait(for: [exp1], timeout: defaultTimeoutSeconds)
-
-        let exp2 = expectation(description: "second custom login")
-        stitchAppClient.auth.logout { _ in
-            self.stitchAppClient.auth.login(withCredential:
-                customAuthClient.credential(withToken: jwt)
-            ) { user, _ in
-                XCTAssertNotNil(user)
-
-                // Ensure that the same user logs in if the token has the same unique user ID.
-                XCTAssertEqual(userId, user!.id)
-
-                exp2.fulfill()
-            }
-        }
-        wait(for: [exp2], timeout: defaultTimeoutSeconds)
-    }
-
-    func testMultipleLoginSemantics() throws {
-        // check storage
-        verifyBasicAuthStorageInfo(loggedIn: false)
-
-        // login anonymously
-        let exp1 = expectation(description: "log in anonymously")
-        var anonUserId: String!
-        self.stitchAppClient.auth.login(
-            withCredential: self.stitchAppClient.auth.providerClient(forProvider:
-                AnonymousAuthProvider.clientSupplier).credential
-        ) { (user: StitchUser?, _) in
-            XCTAssertNotNil(user)
-            anonUserId = user!.id
-
-            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.anonymous)
-            exp1.fulfill()
-        }
-        wait(for: [exp1], timeout: defaultTimeoutSeconds)
-
-        // login anonymously again
-        let exp2 = expectation(description: "log in anonymously again")
-
-        self.stitchAppClient.auth.login(
-            withCredential: self.stitchAppClient.auth.providerClient(forProvider:
-                AnonymousAuthProvider.clientSupplier).credential
-        ) { (user: StitchUser?, _) in
-            XCTAssertNotNil(user)
-
-            // make sure user ID is the name
-            XCTAssertEqual(anonUserId, user!.id)
-
-            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.anonymous)
-            exp2.fulfill()
-        }
-        wait(for: [exp2], timeout: defaultTimeoutSeconds)
-
-        let exp3 = expectation(description: "logged in as email/password user")
-        var emailUserId: String!
-        self.registerAndLogin(email: "test1@10gen.com", password: "hunter1") { user in
-            let nextUserId = user.id
-            XCTAssertNotEqual(anonUserId, nextUserId)
-            emailUserId = nextUserId
-
-            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.userPassword)
-            exp3.fulfill()
-        }
-        wait(for: [exp3], timeout: defaultTimeoutSeconds)
-
-        let exp4 = expectation(description: "logged in as second email/password user")
-        self.registerAndLogin(email: "test2@10gen.com", password: "hunter2") { user in
-            let nextUserId = user.id
-            XCTAssertNotEqual(emailUserId, nextUserId)
-
-            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.userPassword)
-            exp4.fulfill()
-        }
-        wait(for: [exp4], timeout: defaultTimeoutSeconds)
-
-        logoutAndCheckStorage()
-    }
-
-    func testIdentityLinking() throws {
-        let exp1 = expectation(description: "logged in with anonymous provider")
-        var anonUser: StitchUser!
-        self.stitchAppClient.auth.login(
-            withCredential: self.stitchAppClient.auth.providerClient(
-                forProvider: AnonymousAuthProvider.clientSupplier).credential
-        ) { (user, _) in
-            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.anonymous)
-            anonUser = user
-            exp1.fulfill()
-        }
-        wait(for: [exp1], timeout: defaultTimeoutSeconds)
-
-        let userPassClient = self.stitchAppClient.auth.providerClient(
-            forProvider: UserPasswordAuthProvider.clientSupplier
-        )
-
-        let exp2 = expectation(description: "new email/password identity is created and confirmed")
-        userPassClient.register(withEmail: "stitch@10gen.com", withPassword: "password") { error in
-            XCTAssertNil(error)
-            exp2.fulfill()
-        }
-        wait(for: [exp2], timeout: defaultTimeoutSeconds)
-
-        let exp3 = expectation(description: "new email/password identity is confirmed")
-        let conf = try? self.harness.app.userRegistrations.sendConfirmation(toEmail: "stitch@10gen.com")
-        guard let safeConf = conf else {
-            XCTFail("could not retrieve email confirmation token")
-            return
-        }
-
-        userPassClient.confirmUser(withToken: safeConf.token, withTokenId: safeConf.tokenId) { error in
-            XCTAssertNil(error)
-            exp3.fulfill()
-        }
-        wait(for: [exp3], timeout: defaultTimeoutSeconds)
-
-        let exp4 = expectation(description: "original account linked with new email/password identity")
-        anonUser.link(
-            withCredential: userPassClient.credential(forUsername: "stitch@10gen.com", forPassword: "password")
-        ) { linkedUser, _ in
-            XCTAssertNotNil(linkedUser)
-            XCTAssertEqual(anonUser.id, linkedUser!.id)
-            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.userPassword)
-            XCTAssertEqual(linkedUser?.profile.identities.count, 2)
-            exp4.fulfill()
-        }
-        wait(for: [exp4], timeout: defaultTimeoutSeconds)
-
-        logoutAndCheckStorage()
-    }
-
     func testCallFunction() {
         _ = self.harness.addTestFunction()
 
@@ -259,7 +13,6 @@ class StitchAppClientIntegrationTests: StitchIntegrationTestCase {
         let anonAuthClient = stitchAppClient.auth.providerClient(forProvider: AnonymousAuthProvider.clientSupplier)
         stitchAppClient.auth.login(withCredential: anonAuthClient.credential) { user, _ in
             XCTAssertNotNil(user)
-            self.verifyBasicAuthStorageInfo(loggedIn: true, expectedProviderType: StitchProviderType.anonymous)
             exp1.fulfill()
         }
         wait(for: [exp1], timeout: defaultTimeoutSeconds)
@@ -288,5 +41,23 @@ class StitchAppClientIntegrationTests: StitchIntegrationTestCase {
             exp2.fulfill()
         }
         wait(for: [exp2], timeout: defaultTimeoutSeconds)
+
+        let exp3 = expectation(description: "successfully errored out with a timeout when one was specified")
+        stitchAppClient.callFunction(withName: "testFunction",
+                                     withArgs: [randomInt, "hello"],
+                                     withRequestTimeout: 0.00001) { _, error in
+            let stitchError = error as? StitchError
+            XCTAssertNotNil(error as? StitchError)
+            if let err = stitchError {
+                guard case .requestError(_, let errorCode) = err else {
+                    XCTFail("callFunction returned an incorrect error type")
+                    return
+                }
+
+                XCTAssertEqual(errorCode, .transportError)
+            }
+            exp3.fulfill()
+        }
+        wait(for: [exp3], timeout: defaultTimeoutSeconds)
     }
 }

--- a/StitchCore/Sources/StitchCore-AdminClient/StitchAdminClient.swift
+++ b/StitchCore/Sources/StitchCore-AdminClient/StitchAdminClient.swift
@@ -8,14 +8,14 @@ public class StitchAdminClient {
 
     public static let apiPath = "/api/admin/v3.0"
     public static let defaultServerUrl = "http://localhost:9090"
-    public static let defaultTransportTimeout: TimeInterval = 15.0
+    public static let defaultRequestTimeout: TimeInterval = 15.0
 
     public init?(baseUrl: String = defaultServerUrl,
                  transport: Transport = FoundationHTTPTransport.init(),
-                 transportTimeout: TimeInterval = defaultTransportTimeout) {
+                 requestTimeout: TimeInterval = defaultRequestTimeout) {
         let requestClient = StitchRequestClientImpl.init(baseURL: baseUrl,
                                                          transport: transport,
-                                                         transportTimeout: transportTimeout)
+                                                         defaultRequestTimeout: requestTimeout)
 
         self.authRoutes = StitchAdminAuthRoutes.init()
 

--- a/StitchCore/Sources/StitchCore-AdminClient/StitchAdminClient.swift
+++ b/StitchCore/Sources/StitchCore-AdminClient/StitchAdminClient.swift
@@ -8,10 +8,14 @@ public class StitchAdminClient {
 
     public static let apiPath = "/api/admin/v3.0"
     public static let defaultServerUrl = "http://localhost:9090"
+    public static let defaultTransportTimeout: TimeInterval = 15.0
 
     public init?(baseUrl: String = defaultServerUrl,
-                 transport: Transport = FoundationHTTPTransport.init()) {
-        let requestClient = StitchRequestClientImpl.init(baseURL: baseUrl, transport: transport)
+                 transport: Transport = FoundationHTTPTransport.init(),
+                 transportTimeout: TimeInterval = defaultTransportTimeout) {
+        let requestClient = StitchRequestClientImpl.init(baseURL: baseUrl,
+                                                         transport: transport,
+                                                         transportTimeout: transportTimeout)
 
         self.authRoutes = StitchAdminAuthRoutes.init()
 

--- a/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth+StitchAuthRequestClient.swift
+++ b/StitchCore/Sources/StitchCore/Auth/Internal/CoreStitchAuth+StitchAuthRequestClient.swift
@@ -57,6 +57,7 @@ extension CoreStitchAuth: StitchAuthRequestClient {
         builder.path = stitchReq.path
         builder.useRefreshToken = stitchReq.useRefreshToken
         builder.method = stitchReq.method
+        builder.timeout = stitchReq.timeout
         builder.body = try JSONSerialization.data(withJSONObject: stitchReq.document.toExtendedJSON)
         builder.document = stitchReq.document
         builder.headers = stitchReq.headers.merging(
@@ -92,6 +93,7 @@ extension CoreStitchAuth: StitchAuthRequestClient {
             $0.path = stitchReq.path
             $0.method = stitchReq.method
             $0.body = stitchReq.body
+            $0.timeout = stitchReq.timeout
         }.build()
     }
 

--- a/StitchCore/Sources/StitchCore/Auth/Internal/StitchAuthRequestClient.swift
+++ b/StitchCore/Sources/StitchCore/Auth/Internal/StitchAuthRequestClient.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /**
  * A protocol defining the methods necessary to make authenticated requests to the Stitch server.
  */

--- a/StitchCore/Sources/StitchCore/Internal/CoreStitchAppClient.swift
+++ b/StitchCore/Sources/StitchCore/Internal/CoreStitchAppClient.swift
@@ -1,4 +1,5 @@
 import ExtendedJSON
+import Foundation
 
 /**
  * A class providing the core functionality necessary for a Stitch app client to make authenticated function call
@@ -37,9 +38,10 @@ public final class CoreStitchAppClient {
      * - returns: An `Any` representing the decoded JSON of the result of the function call.
      */
     public func callFunctionInternal(withName name: String,
-                                     withArgs args: BSONArray) throws -> Any {
+                                     withArgs args: BSONArray,
+                                     withRequestTimeout requestTimeout: TimeInterval? = nil) throws -> Any {
         return try self.authRequestClient.doAuthenticatedJSONRequest(
-            callFunctionRequest(withName: name, withArgs: args)
+            callFunctionRequest(withName: name, withArgs: args, withRequestTimeout: requestTimeout)
         )
     }
 
@@ -48,11 +50,13 @@ public final class CoreStitchAppClient {
      * and arguments as parameters.
      */
     private func callFunctionRequest(withName name: String,
-                                     withArgs args: BSONArray) throws -> StitchAuthDocRequest {
+                                     withArgs args: BSONArray,
+                                     withRequestTimeout requestTimeout: TimeInterval?) throws -> StitchAuthDocRequest {
         let route = self.routes.serviceRoutes.functionCallRoute
         return try StitchAuthDocRequestBuilderImpl {
             $0.method = .post
             $0.path = route
+            $0.timeout = requestTimeout
             $0.document = [
                 "name": name,
                 "arguments": args

--- a/StitchCore/Sources/StitchCore/Internal/Net/FoundationHTTPTransport.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/FoundationHTTPTransport.swift
@@ -17,8 +17,11 @@ public final class FoundationHTTPTransport: Transport {
         guard let url = URL(string: request.url) else {
             throw StitchError.clientError(withClientErrorCode: .missingURL)
         }
+        
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.timeoutIntervalForResource = request.timeout
 
-        let defaultSession = URLSession(configuration: URLSessionConfiguration.default)
+        let session = URLSession(configuration: sessionConfig)
 
         var contentHeaders = request.headers
         contentHeaders[Headers.contentType.rawValue] =
@@ -38,7 +41,7 @@ public final class FoundationHTTPTransport: Transport {
         var finalResponse: Response?
         var error: Error?
 
-        defaultSession.dataTask(with: urlRequest) { data, response, err in
+        session.dataTask(with: urlRequest) { data, response, err in
             defer { sema.signal() }
             guard let urlResponse = response as? HTTPURLResponse,
                 let headers = urlResponse.allHeaderFields as? [String: String]

--- a/StitchCore/Sources/StitchCore/Internal/Net/Requests/Request.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/Requests/Request.swift
@@ -6,6 +6,7 @@ import Foundation
 public enum RequestBuilderError: Error {
     case missingMethod
     case missingUrl
+    case missingTimeout
 }
 
 /**
@@ -26,6 +27,12 @@ public struct RequestBuilder: Builder {
      * The URL of the request to be built.
      */
     public var url: String?
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error.
+     */
+    public var timeout: TimeInterval?
 
     /**
      * The HTTP headers of the request to be built.
@@ -56,7 +63,6 @@ public struct RequestBuilder: Builder {
  * An HTTP request that can be made to an arbitrary server.
  */
 public struct Request: Buildee {
-
     /**
      * The type that builds this request object.
      */
@@ -73,6 +79,12 @@ public struct Request: Buildee {
      * The URL to which this request will be made.
      */
     public var url: String
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error.
+     */
+    public var timeout: TimeInterval
 
     /**
      * The HTTP headers of this request.
@@ -89,7 +101,7 @@ public struct Request: Buildee {
     /**
      * Initializes this request by accepting a `RequestBuilder`.
      *
-     * - throws: `RequestBuilderError` if the builder is missing an HTTP method or a URL.
+     * - throws: `RequestBuilderError` if the builder is missing an HTTP method, a URL, or a timeout.
      */
     public init(_ builder: RequestBuilder) throws {
         guard let method = builder.method else {
@@ -98,9 +110,13 @@ public struct Request: Buildee {
         guard let url = builder.url else {
             throw RequestBuilderError.missingUrl
         }
+        guard let timeout = builder.timeout else {
+            throw RequestBuilderError.missingTimeout
+        }
 
         self.method = method
         self.url = url
+        self.timeout = timeout
 
         self.headers = builder.headers ?? [:]
         self.body = builder.body

--- a/StitchCore/Sources/StitchCore/Internal/Net/Requests/StitchAuthRequest.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/Requests/StitchAuthRequest.swift
@@ -40,6 +40,13 @@ public struct StitchAuthRequestBuilderImpl: StitchAuthRequestBuilder {
      * The HTTP method of the request to be built.
      */
     public var method: Method?
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error. If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    public var timeout: TimeInterval?
 
     /**
      * The HTTP headers of the request to be built.
@@ -106,6 +113,13 @@ public struct StitchAuthRequestImpl: StitchAuthRequest {
      * The HTTP method of this request.
      */
     public var method: Method
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error. If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    public var timeout: TimeInterval?
 
     /**
      * The HTTP headers of this request.
@@ -150,6 +164,7 @@ public struct StitchAuthRequestImpl: StitchAuthRequest {
         self.useRefreshToken = builder.useRefreshToken ?? false
         self.path = path
         self.method = method
+        self.timeout = builder.timeout
         self.headers = builder.headers ?? [:]
         self.body = builder.body
         self.startedAt = Date().timeIntervalSince1970
@@ -195,6 +210,13 @@ public struct StitchAuthDocRequestBuilderImpl: StitchAuthDocRequestBuilder {
      * The HTTP method of the request to be built.
      */
     public var method: Method?
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error. If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    public var timeout: TimeInterval?
 
     /**
      * The HTTP headers of the request to be built.
@@ -246,6 +268,13 @@ public struct StitchAuthDocRequest: StitchAuthRequest {
      * The HTTP method of this request.
      */
     public var method: Method
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error. If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    public var timeout: TimeInterval?
 
     /**
      * The HTTP headers of this request.
@@ -294,6 +323,7 @@ public struct StitchAuthDocRequest: StitchAuthRequest {
         self.useRefreshToken = builder.useRefreshToken ?? false
         self.path = path
         self.method = method
+        self.timeout = builder.timeout
         self.headers = builder.headers ?? [:]
         self.body = builder.body
         self.startedAt = Date().timeIntervalSince1970

--- a/StitchCore/Sources/StitchCore/Internal/Net/Requests/StitchRequest.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/Requests/StitchRequest.swift
@@ -14,6 +14,13 @@ public protocol StitchRequestBuilder: Builder {
      * The HTTP headers of the request to be built.
      */
     var headers: [String: String]? { get set }
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error. If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    var timeout: TimeInterval? { get set }
 
     /**
      * The body of the rqeuest to be built.
@@ -49,6 +56,13 @@ public struct StitchRequestBuilderImpl: StitchRequestBuilder {
      * The HTTP headers of the request to be built.
      */
     public var headers: [String: String]?
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error. If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    public var timeout: TimeInterval?
 
     /**
      * The URL of the request to be built.
@@ -88,6 +102,13 @@ public protocol StitchRequest: Buildee {
      * The HTTP headers of this request.
      */
     var headers: [String: String] { get }
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error. If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    var timeout: TimeInterval? { get }
 
     /**
      * The body of the request.
@@ -126,6 +147,13 @@ public struct StitchRequestImpl: StitchRequest {
     public let headers: [String: String]
 
     /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error.  If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    public let timeout: TimeInterval?
+    
+    /**
      * The body of the request.
      */
     public let body: Data?
@@ -152,6 +180,7 @@ public struct StitchRequestImpl: StitchRequest {
         self.path = path
         self.method = method
         self.headers = builder.headers ?? [:]
+        self.timeout = builder.timeout
         self.body = builder.body
         self.startedAt = Date().timeIntervalSince1970
     }
@@ -197,6 +226,13 @@ public struct StitchDocRequestBuilderImpl: StitchDocRequestBuilder {
      * The HTTP method of the request to be built.
      */
     public var method: Method?
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error.  If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    public var timeout: TimeInterval?
 
     /**
      * The HTTP headers of the request to be built.
@@ -237,6 +273,13 @@ public struct StitchDocRequest: StitchRequest {
      * The HTTP method of this request.
      */
     public var method: Method
+    
+    /**
+     * The number of seconds that the underlying transport should spend on an HTTP round trip before failing with an
+     * error. If not configured, a default should override it before the request is transformed into a plain HTTP
+     * request.
+     */
+    public var timeout: TimeInterval?
 
     /**
      * The HTTP headers of this request.
@@ -276,8 +319,11 @@ public struct StitchDocRequest: StitchRequest {
             throw RequestBuilderError.missingMethod
         }
 
+
         self.path = path
         self.method = method
+        
+        self.timeout = builder.timeout
         self.headers = builder.headers ?? [:]
         self.body = builder.body
         self.document = document

--- a/StitchCore/Sources/StitchCore/Internal/Net/StitchRequestClient.swift
+++ b/StitchCore/Sources/StitchCore/Internal/Net/StitchRequestClient.swift
@@ -20,7 +20,7 @@ public protocol StitchRequestClient {
     /**
      * Initializes the request client with the provided base URL and `Transport`.
      */
-    init(baseURL: String, transport: Transport, transportTimeout: TimeInterval)
+    init(baseURL: String, transport: Transport, defaultRequestTimeout: TimeInterval)
 
     /**
      * Performs a request against the Stitch server with the given `StitchRequest` object.
@@ -52,18 +52,21 @@ public final class StitchRequestClientImpl: StitchRequestClient {
     private let transport: Transport
     
     /**
-     * The number of seconds that the underlying `Transport` should spend on an HTTP round trip before failing with an
-     * error. Does not override any timeout settings configured by the underlying transport.
+     * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
+     * error.
+     *
+     * - important: If a request timeout was specified for a specific operation, for example in a function call, that
+     *              timeout should override this one.
      */
-    private let transportTimeout: TimeInterval
+    private let defaultRequestTimeout: TimeInterval
 
     /**
      * Initializes the request client with the provided base URL and `Transport`.
      */
-    public init(baseURL: String, transport: Transport, transportTimeout: TimeInterval) {
+    public init(baseURL: String, transport: Transport, defaultRequestTimeout: TimeInterval) {
         self.baseURL = baseURL
         self.transport = transport
-        self.transportTimeout = transportTimeout
+        self.defaultRequestTimeout = defaultRequestTimeout
     }
 
     /**
@@ -72,35 +75,14 @@ public final class StitchRequestClientImpl: StitchRequestClient {
      * - returns: the response to the request as a `Response` object.
      */
     public func doRequest<R>(_ stitchReq: R) throws -> Response where R: StitchRequest {
-        let transportTask = DispatchGroup.init()
         var response: Response!
-        var errorToThrow: Error?
-        
-        transportTask.enter()
-        DispatchQueue.global().async {
-            do {
-                response = try self.transport.roundTrip(request: self.buildRequest(stitchReq))
-            } catch let error {
-                // Wrap the error from the transport in a `StitchError.requestError`
-                errorToThrow = StitchError.requestError(withError: error, withRequestErrorCode: .transportError)
-            }
-            
-            transportTask.leave()
+        do {
+            response = try self.transport.roundTrip(request: self.buildRequest(stitchReq))
+        } catch {
+            // Wrap the error from the transport in a `StitchError.requestError`
+            throw StitchError.requestError(withError: error, withRequestErrorCode: .transportError)
         }
-        
-        let taskResult = transportTask.wait(timeout: DispatchTime.now() + self.transportTimeout)
-        
-        switch taskResult {
-        case .success:
-            if let error = errorToThrow {
-                throw error
-            }
-            
-            return try inspectResponse(response: response)
-            
-        case .timedOut:
-            throw StitchError.requestError(withError: nil, withRequestErrorCode: .transportTimeoutError)
-        }
+        return try inspectResponse(response: response)
     }
 
     /**
@@ -117,6 +99,7 @@ public final class StitchRequestClientImpl: StitchRequestClient {
             ]
             builder.path = stitchReq.path
             builder.method = stitchReq.method
+            builder.timeout = stitchReq.timeout
         }.build())
     }
 
@@ -127,6 +110,7 @@ public final class StitchRequestClientImpl: StitchRequestClient {
         return try RequestBuilder { builder in
             builder.method = stitchReq.method
             builder.url = "\(self.baseURL)\(stitchReq.path)"
+            builder.timeout = stitchReq.timeout ?? self.defaultRequestTimeout
             builder.headers = stitchReq.headers
             builder.body = stitchReq.body
         }.build()

--- a/StitchCore/Sources/StitchCore/Services/Internal/CoreStitchService.swift
+++ b/StitchCore/Sources/StitchCore/Services/Internal/CoreStitchService.swift
@@ -1,4 +1,5 @@
 import ExtendedJSON
+import Foundation
 
 /**
  * A class providing the core functionality necessary to make authenticated function call requests for a particular
@@ -45,9 +46,10 @@ open class CoreStitchService {
      * - returns: An `Any` representing the decoded JSON of the result of the function call.
      */
     public func callFunctionInternal(withName name: String,
-                                     withArgs args: BSONArray) throws -> Any {
+                                     withArgs args: BSONArray,
+                                     withRequestTimeout requestTimeout: TimeInterval? = nil) throws -> Any {
         return try self.requestClient.doAuthenticatedJSONRequest(
-            callFunctionRequest(withName: name, withArgs: args)
+            callFunctionRequest(withName: name, withArgs: args, withRequestTimeout: requestTimeout)
         )
     }
 
@@ -56,10 +58,12 @@ open class CoreStitchService {
      * the function name and arguments as parameters.
      */
     private final func callFunctionRequest(withName name: String,
-                                           withArgs args: BSONArray) throws -> StitchAuthDocRequest {
+                                           withArgs args: BSONArray,
+                                           withRequestTimeout requestTimeout: TimeInterval?) throws -> StitchAuthDocRequest {
         return try StitchAuthDocRequestBuilderImpl {
             $0.method = .post
             $0.path = self.serviceRoutes.functionCallRoute
+            $0.timeout = requestTimeout
             $0.document = [
                 "name": name,
                 "service": self.serviceName,

--- a/StitchCore/Sources/StitchCore/StitchAppClientConfiguration.swift
+++ b/StitchCore/Sources/StitchCore/StitchAppClientConfiguration.swift
@@ -51,13 +51,13 @@ public struct StitchAppClientConfigurationImpl: StitchAppClientConfiguration, Bu
     public let transport: Transport
     
     /**
-     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
+     * error.
      *
-     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
-     *              throw a timeout error before this specified interval. If you experience premature timeouts,
-     *              configure your underlying transport to have a longer timeout interval.
+     * - important: If a request timeout was specified for a specific operation, for example in a function call, that
+     *              timeout will override this one.
      */
-    public let transportTimeout: TimeInterval
+    public let defaultRequestTimeout: TimeInterval
 
     /**
      * The client app id of the Stitch application that this client is going to communicate with.
@@ -115,15 +115,15 @@ public struct StitchAppClientConfigurationImpl: StitchAppClientConfiguration, Bu
             throw StitchClientConfigurationError.missingTransport
         }
         
-        guard let transportTimeout = builder.transportTimeout else {
-            throw StitchClientConfigurationError.missingTransportTimeout
+        guard let defaultRequestTimeout = builder.defaultRequestTimeout else {
+            throw StitchClientConfigurationError.missingDefaultRequestTimeout
         }
 
         self.baseURL = baseURL
         self.dataDirectory = dataDirectory
         self.storage = storage
         self.transport = transport
-        self.transportTimeout = transportTimeout
+        self.defaultRequestTimeout = defaultRequestTimeout
     }
 }
 
@@ -165,13 +165,13 @@ public struct StitchAppClientConfigurationBuilder: StitchClientConfigurationBuil
     public var transport: Transport?
     
     /**
-     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
+     * error.
      *
-     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
-     *              throw a timeout error before this specified interval. If you experience premature timeouts,
-     *              configure your underlying transport to have a longer timeout interval.
+     * - important: If a request timeout was specified for a specific operation, for example in a function call, that
+     *              timeout will override this one.
      */
-    public var transportTimeout: TimeInterval?
+    public var defaultRequestTimeout: TimeInterval?
 
     /**
      * The client app id of the Stitch application that this client is going to communicate with.

--- a/StitchCore/Sources/StitchCore/StitchAppClientConfiguration.swift
+++ b/StitchCore/Sources/StitchCore/StitchAppClientConfiguration.swift
@@ -49,6 +49,15 @@ public struct StitchAppClientConfigurationImpl: StitchAppClientConfiguration, Bu
      * The `Transport` that the client will use to make round trips to the Stitch server.
      */
     public let transport: Transport
+    
+    /**
+     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     *
+     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
+     *              throw a timeout error before this specified interval. If you experience premature timeouts,
+     *              configure your underlying transport to have a longer timeout interval.
+     */
+    public let transportTimeout: TimeInterval
 
     /**
      * The client app id of the Stitch application that this client is going to communicate with.
@@ -105,11 +114,16 @@ public struct StitchAppClientConfigurationImpl: StitchAppClientConfiguration, Bu
         guard let transport = builder.transport else {
             throw StitchClientConfigurationError.missingTransport
         }
+        
+        guard let transportTimeout = builder.transportTimeout else {
+            throw StitchClientConfigurationError.missingTransportTimeout
+        }
 
         self.baseURL = baseURL
         self.dataDirectory = dataDirectory
         self.storage = storage
         self.transport = transport
+        self.transportTimeout = transportTimeout
     }
 }
 
@@ -149,6 +163,15 @@ public struct StitchAppClientConfigurationBuilder: StitchClientConfigurationBuil
      * The `Transport` that the client will use to make round trips to the Stitch server.
      */
     public var transport: Transport?
+    
+    /**
+     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     *
+     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
+     *              throw a timeout error before this specified interval. If you experience premature timeouts,
+     *              configure your underlying transport to have a longer timeout interval.
+     */
+    public var transportTimeout: TimeInterval?
 
     /**
      * The client app id of the Stitch application that this client is going to communicate with.

--- a/StitchCore/Sources/StitchCore/StitchClientConfiguration.swift
+++ b/StitchCore/Sources/StitchCore/StitchClientConfiguration.swift
@@ -26,13 +26,13 @@ public protocol StitchClientConfiguration {
     var transport: Transport { get }
     
     /**
-     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
+     * error.
      *
-     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
-     *              throw a timeout error before this specified interval. If you experience premature timeouts,
-     *              configure your underlying transport to have a longer timeout interval.
+     * - important: If a request timeout was specified for a specific operation, for example in a function call, that
+     *              timeout will override this one.
      */
-    var transportTimeout: TimeInterval { get }
+    var defaultRequestTimeout: TimeInterval { get }
 }
 
 /**
@@ -66,13 +66,13 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
     public let transport: Transport
     
     /**
-     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
+     * error.
      *
-     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
-     *              throw a timeout error before this specified interval. If you experience premature timeouts,
-     *              configure your underlying transport to have a longer timeout interval.
+     * - important: If a request timeout was specified for a specific operation, for example in a function call, that
+     *              timeout will override this one.
      */
-    public let transportTimeout: TimeInterval
+    public let defaultRequestTimeout: TimeInterval
 
     /**
      * Initializes this configuration by accepting a `StitchClientConfigurationBuilderImpl`.
@@ -96,15 +96,15 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
             throw StitchClientConfigurationError.missingTransport
         }
         
-        guard let transportTimeout = builder.transportTimeout else {
-            throw StitchClientConfigurationError.missingTransportTimeout
+        guard let defaultRequestTimeout = builder.defaultRequestTimeout else {
+            throw StitchClientConfigurationError.missingDefaultRequestTimeout
         }
 
         self.baseURL = baseURL
         self.dataDirectory = dataDirectory
         self.storage = storage
         self.transport = transport
-        self.transportTimeout = transportTimeout
+        self.defaultRequestTimeout = defaultRequestTimeout
     }
 }
 
@@ -117,7 +117,7 @@ public enum StitchClientConfigurationError: Error {
     case missingDataDirectory
     case missingStorage
     case missingTransport
-    case missingTransportTimeout
+    case missingDefaultRequestTimeout
 }
 
 /**
@@ -146,13 +146,13 @@ public protocol StitchClientConfigurationBuilder {
     var transport: Transport? { get }
     
     /**
-     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
+     * error.
      *
-     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
-     *              throw a timeout error before this specified interval. If you experience premature timeouts,
-     *              configure your underlying transport to have a longer timeout interval.
+     * - important: If a request timeout was specified for a specific operation, for example in a function call, that
+     *              timeout will override this one.
      */
-    var transportTimeout: TimeInterval? { get }
+    var defaultRequestTimeout: TimeInterval? { get }
 }
 
 /**
@@ -181,13 +181,13 @@ public struct StitchClientConfigurationBuilderImpl: StitchClientConfigurationBui
     public var transport: Transport?
     
     /**
-     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
+     * error.
      *
-     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
-     *              throw a timeout error before this specified interval. If you experience premature timeouts,
-     *              configure your underlying transport to have a longer timeout interval.
+     * - important: If a request timeout was specified for a specific operation, for example in a function call, that
+     *              timeout will override this one.
      */
-    public var transportTimeout: TimeInterval?
+    public var defaultRequestTimeout: TimeInterval?
 
     /**
      * The type that this builder builds.

--- a/StitchCore/Sources/StitchCore/StitchClientConfiguration.swift
+++ b/StitchCore/Sources/StitchCore/StitchClientConfiguration.swift
@@ -21,9 +21,18 @@ public protocol StitchClientConfiguration {
     var storage: Storage { get }
 
     /**
-     * The `Transport` that the client will use to make round trips to the Stitch server.
+     * The `Transport` that the client will use to make HTTP round trips to the Stitch server.
      */
     var transport: Transport { get }
+    
+    /**
+     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     *
+     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
+     *              throw a timeout error before this specified interval. If you experience premature timeouts,
+     *              configure your underlying transport to have a longer timeout interval.
+     */
+    var transportTimeout: TimeInterval { get }
 }
 
 /**
@@ -52,9 +61,18 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
     public let storage: Storage
 
     /**
-     * The `Transport` that the client will use to make round trips to the Stitch server.
+     * The `Transport` that the client will use to make HTTP round trips to the Stitch server.
      */
     public let transport: Transport
+    
+    /**
+     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     *
+     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
+     *              throw a timeout error before this specified interval. If you experience premature timeouts,
+     *              configure your underlying transport to have a longer timeout interval.
+     */
+    public let transportTimeout: TimeInterval
 
     /**
      * Initializes this configuration by accepting a `StitchClientConfigurationBuilderImpl`.
@@ -77,11 +95,16 @@ public struct StitchClientConfigurationImpl: StitchClientConfiguration, Buildee 
         guard let transport = builder.transport else {
             throw StitchClientConfigurationError.missingTransport
         }
+        
+        guard let transportTimeout = builder.transportTimeout else {
+            throw StitchClientConfigurationError.missingTransportTimeout
+        }
 
         self.baseURL = baseURL
         self.dataDirectory = dataDirectory
         self.storage = storage
         self.transport = transport
+        self.transportTimeout = transportTimeout
     }
 }
 
@@ -94,6 +117,7 @@ public enum StitchClientConfigurationError: Error {
     case missingDataDirectory
     case missingStorage
     case missingTransport
+    case missingTransportTimeout
 }
 
 /**
@@ -117,9 +141,18 @@ public protocol StitchClientConfigurationBuilder {
     var storage: Storage? { get }
 
     /**
-     * The `Transport` that the client will use to make round trips to the Stitch server.
+     * The `Transport` that the client will use to make HTTP round trips to the Stitch server.
      */
     var transport: Transport? { get }
+    
+    /**
+     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     *
+     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
+     *              throw a timeout error before this specified interval. If you experience premature timeouts,
+     *              configure your underlying transport to have a longer timeout interval.
+     */
+    var transportTimeout: TimeInterval? { get }
 }
 
 /**
@@ -143,9 +176,18 @@ public struct StitchClientConfigurationBuilderImpl: StitchClientConfigurationBui
     public var storage: Storage?
 
     /**
-     * The `Transport` that the client will use to make round trips to the Stitch server.
+     * The `Transport` that the client will use to make HTTP round trips to the Stitch server.
      */
     public var transport: Transport?
+    
+    /**
+     * The number of seconds that a `Transport` should spend on an HTTP round trip before failing with an error.
+     *
+     * - important: If the underlying transport internally handles timeouts, it is possible that the transport will
+     *              throw a timeout error before this specified interval. If you experience premature timeouts,
+     *              configure your underlying transport to have a longer timeout interval.
+     */
+    public var transportTimeout: TimeInterval?
 
     /**
      * The type that this builder builds.

--- a/StitchCore/Sources/StitchCore/StitchError.swift
+++ b/StitchCore/Sources/StitchCore/StitchError.swift
@@ -22,9 +22,10 @@ public enum StitchError: Error {
      * transport errors, these errors are thrown by the underlying `Transport` of the Stitch client, and thus contain
      * the error that the transport threw. Errors in decoding the result from the server include the specific error
      * thrown when attempting to decode the response. An error code is included, which indicates whether the error
-     * was a transport error or decoding error..
+     * was a transport error or decoding error. If the underlying transport times out based on the configured
+     * timeout interval, there will be no underying error specified.
      */
-    case requestError(withError: Error, withRequestErrorCode: StitchRequestErrorCode)
+    case requestError(withError: Error?, withRequestErrorCode: StitchRequestErrorCode)
 
     /**
      * Indicates that an error occurred when using the Stitch client, typically before the client performed a request.
@@ -93,6 +94,7 @@ public enum StitchServiceErrorCode: String, Codable {
  */
 public enum StitchRequestErrorCode {
     case transportError
+    case transportTimeoutError
     case decodingError
 }
 

--- a/StitchCore/Sources/StitchCore/StitchError.swift
+++ b/StitchCore/Sources/StitchCore/StitchError.swift
@@ -22,10 +22,9 @@ public enum StitchError: Error {
      * transport errors, these errors are thrown by the underlying `Transport` of the Stitch client, and thus contain
      * the error that the transport threw. Errors in decoding the result from the server include the specific error
      * thrown when attempting to decode the response. An error code is included, which indicates whether the error
-     * was a transport error or decoding error. If the underlying transport times out based on the configured
-     * timeout interval, there will be no underying error specified.
+     * was a transport error or decoding error.
      */
-    case requestError(withError: Error?, withRequestErrorCode: StitchRequestErrorCode)
+    case requestError(withError: Error, withRequestErrorCode: StitchRequestErrorCode)
 
     /**
      * Indicates that an error occurred when using the Stitch client, typically before the client performed a request.
@@ -94,7 +93,6 @@ public enum StitchServiceErrorCode: String, Codable {
  */
 public enum StitchRequestErrorCode {
     case transportError
-    case transportTimeoutError
     case decodingError
 }
 

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
@@ -80,7 +80,7 @@ final class MockStitchRequestClient: StitchRequestClient {
     }
 
     init() { }
-    init(baseURL: String, transport: Transport) { }
+    init(baseURL: String, transport: Transport, transportTimeout: TimeInterval) { }
 
     private func checkAuth(headers: [String: String]) throws {
         guard let authHeader = headers["Authorization"] else {

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Internal/CoreStitchAuthTests.swift
@@ -80,7 +80,7 @@ final class MockStitchRequestClient: StitchRequestClient {
     }
 
     init() { }
-    init(baseURL: String, transport: Transport, transportTimeout: TimeInterval) { }
+    init(baseURL: String, transport: Transport, defaultRequestTimeout: TimeInterval) { }
 
     private func checkAuth(headers: [String: String]) throws {
         guard let authHeader = headers["Authorization"] else {

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Providers/UserPass/CoreUserPasswordAuthProviderClientTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Providers/UserPass/CoreUserPasswordAuthProviderClientTests.swift
@@ -56,7 +56,7 @@ class CoreUserPasswordAuthProviderClientTests: StitchXCTestCase {
             withProviderName: self.providerName,
             withRequestClient: StitchRequestClientImpl.init(baseURL: self.baseURL,
                                                             transport: FoundationHTTPTransport(),
-                                                            transportTimeout: defaultTestTransportTimeout),
+                                                            defaultRequestTimeout: testDefaultRequestTimeout),
             withRoutes: routes.authRoutes
         )
     }

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Providers/UserPass/CoreUserPasswordAuthProviderClientTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Auth/Providers/UserPass/CoreUserPasswordAuthProviderClientTests.swift
@@ -55,7 +55,8 @@ class CoreUserPasswordAuthProviderClientTests: StitchXCTestCase {
         core = CoreUserPasswordAuthProviderClient.init(
             withProviderName: self.providerName,
             withRequestClient: StitchRequestClientImpl.init(baseURL: self.baseURL,
-                                                        transport: FoundationHTTPTransport()),
+                                                            transport: FoundationHTTPTransport(),
+                                                            transportTimeout: defaultTestTransportTimeout),
             withRoutes: routes.authRoutes
         )
     }

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/FoundationHTTPTransportTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/FoundationHTTPTransportTests.swift
@@ -38,6 +38,7 @@ class FoundationHTTPTransportTests: StitchXCTestCase {
         var builder = Request.TBuilder {
             $0.method = .get
             $0.url = "badURL"
+            $0.timeout = testDefaultRequestTimeout
             $0.headers = self.headers
         }
 

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/StitchRequestClientTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/StitchRequestClientTests.swift
@@ -13,6 +13,7 @@ class StitchRequestClientTests: StitchXCTestCase {
     let getEndpoint = "/get"
     let notGetEndpoint = "/notget"
     let badRequestEndpoint = "/badreq"
+    let timeoutEndpoint = "/timeout"
 
     override func setUp() {
         self.server[self.getEndpoint] = { request in
@@ -25,13 +26,18 @@ class StitchRequestClientTests: StitchXCTestCase {
         self.server[self.badRequestEndpoint] = { request in
             return .badRequest(.text("bad request"))
         }
+        self.server[self.timeoutEndpoint] = { request in
+            Thread.sleep(forTimeInterval: 20.0) // sleep for 20 seconds
+            return .ok(.text("This response will not be seen since the client will timeout"))
+        }
 
         super.setUp()
     }
 
     func testDoRequest() throws {
         let stitchRequestClient = StitchRequestClientImpl.init(baseURL: self.baseURL,
-                                                           transport: FoundationHTTPTransport())
+                                                               transport: FoundationHTTPTransport(),
+                                                               transportTimeout: defaultTestTransportTimeout)
 
         var builder = StitchRequestImpl.TBuilder {
             $0.path = self.badRequestEndpoint
@@ -56,10 +62,35 @@ class StitchRequestClientTests: StitchXCTestCase {
         XCTAssertEqual(response.statusCode, 200)
         XCTAssertEqual(response.body, self.responseBody.data(using: .utf8))
     }
+    
+    func testDoRequestWithTimeout() throws {
+        let stitchRequestClient = StitchRequestClientImpl.init(baseURL: self.baseURL,
+                                                               transport: FoundationHTTPTransport(),
+                                                               transportTimeout: 3.0)
+        
+        let builder = StitchRequestImpl.TBuilder {
+            $0.path = self.timeoutEndpoint
+            $0.method = .get
+        }
+        
+        XCTAssertThrowsError(try stitchRequestClient.doRequest(builder.build())) { error in
+            let stitchError = error as? StitchError
+            XCTAssertNotNil(error as? StitchError)
+            if let err = stitchError {
+                guard case .requestError(_, let errorCode) = err else {
+                    XCTFail("doRequest returned an incorrect error type")
+                    return
+                }
+                
+                XCTAssertEqual(errorCode, .transportTimeoutError)
+            }
+        }
+    }
 
     func testDoJSONRequestRaw() throws {
         let stitchRequestClient = StitchRequestClientImpl.init(baseURL: self.baseURL,
-                                                           transport: FoundationHTTPTransport())
+                                                               transport: FoundationHTTPTransport(),
+                                                               transportTimeout: defaultTestTransportTimeout)
 
         var builder = StitchDocRequestBuilderImpl {
             $0.path = self.badRequestEndpoint

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/StitchRequestClientTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/Internal/Net/StitchRequestClientTests.swift
@@ -37,7 +37,7 @@ class StitchRequestClientTests: StitchXCTestCase {
     func testDoRequest() throws {
         let stitchRequestClient = StitchRequestClientImpl.init(baseURL: self.baseURL,
                                                                transport: FoundationHTTPTransport(),
-                                                               transportTimeout: defaultTestTransportTimeout)
+                                                               defaultRequestTimeout: testDefaultRequestTimeout)
 
         var builder = StitchRequestImpl.TBuilder {
             $0.path = self.badRequestEndpoint
@@ -66,11 +66,12 @@ class StitchRequestClientTests: StitchXCTestCase {
     func testDoRequestWithTimeout() throws {
         let stitchRequestClient = StitchRequestClientImpl.init(baseURL: self.baseURL,
                                                                transport: FoundationHTTPTransport(),
-                                                               transportTimeout: 3.0)
+                                                               defaultRequestTimeout: testDefaultRequestTimeout)
         
         let builder = StitchRequestImpl.TBuilder {
             $0.path = self.timeoutEndpoint
             $0.method = .get
+            $0.timeout = 3.0
         }
         
         XCTAssertThrowsError(try stitchRequestClient.doRequest(builder.build())) { error in
@@ -82,7 +83,7 @@ class StitchRequestClientTests: StitchXCTestCase {
                     return
                 }
                 
-                XCTAssertEqual(errorCode, .transportTimeoutError)
+                XCTAssertEqual(errorCode, .transportError)
             }
         }
     }
@@ -90,7 +91,7 @@ class StitchRequestClientTests: StitchXCTestCase {
     func testDoJSONRequestRaw() throws {
         let stitchRequestClient = StitchRequestClientImpl.init(baseURL: self.baseURL,
                                                                transport: FoundationHTTPTransport(),
-                                                               transportTimeout: defaultTestTransportTimeout)
+                                                               defaultRequestTimeout: testDefaultRequestTimeout)
 
         var builder = StitchDocRequestBuilderImpl {
             $0.path = self.badRequestEndpoint

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchAppClientConfigurationTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchAppClientConfigurationTests.swift
@@ -9,7 +9,7 @@ class StitchAppClientConfigurationBuilderTests: XCTestCase {
     private let dataDirectory = URL.init(string: "foo/bar/baz/qux")!
     private let storage = MemoryStorage.init()
     private let transport = FoundationHTTPTransport.init()
-    private let transportTimeout: TimeInterval = defaultTestTransportTimeout
+    private let defaultRequestTimeout: TimeInterval = testDefaultRequestTimeout
 
     func testStitchAppClientConfigurationBuilderInit() throws {
         var builder = StitchAppClientConfigurationBuilder { _ in }
@@ -53,10 +53,10 @@ class StitchAppClientConfigurationBuilderTests: XCTestCase {
         
         XCTAssertThrowsError(try builder.build()) { error in
             XCTAssertEqual(error as? StitchClientConfigurationError,
-                           StitchClientConfigurationError.missingTransportTimeout)
+                           StitchClientConfigurationError.missingDefaultRequestTimeout)
         }
         
-        builder.transportTimeout = self.transportTimeout
+        builder.defaultRequestTimeout = self.defaultRequestTimeout
 
         let config = try builder.build()
 
@@ -66,6 +66,6 @@ class StitchAppClientConfigurationBuilderTests: XCTestCase {
         XCTAssertEqual(config.baseURL, self.baseURL)
         XCTAssert(config.storage is MemoryStorage)
         XCTAssert(config.transport is FoundationHTTPTransport)
-        XCTAssertEqual(config.transportTimeout, self.transportTimeout)
+        XCTAssertEqual(config.defaultRequestTimeout, self.defaultRequestTimeout)
     }
 }

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchAppClientConfigurationTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchAppClientConfigurationTests.swift
@@ -9,6 +9,7 @@ class StitchAppClientConfigurationBuilderTests: XCTestCase {
     private let dataDirectory = URL.init(string: "foo/bar/baz/qux")!
     private let storage = MemoryStorage.init()
     private let transport = FoundationHTTPTransport.init()
+    private let transportTimeout: TimeInterval = defaultTestTransportTimeout
 
     func testStitchAppClientConfigurationBuilderInit() throws {
         var builder = StitchAppClientConfigurationBuilder { _ in }
@@ -49,6 +50,13 @@ class StitchAppClientConfigurationBuilderTests: XCTestCase {
         }
 
         builder.transport = self.transport
+        
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(error as? StitchClientConfigurationError,
+                           StitchClientConfigurationError.missingTransportTimeout)
+        }
+        
+        builder.transportTimeout = self.transportTimeout
 
         let config = try builder.build()
 
@@ -58,5 +66,6 @@ class StitchAppClientConfigurationBuilderTests: XCTestCase {
         XCTAssertEqual(config.baseURL, self.baseURL)
         XCTAssert(config.storage is MemoryStorage)
         XCTAssert(config.transport is FoundationHTTPTransport)
+        XCTAssertEqual(config.transportTimeout, self.transportTimeout)
     }
 }

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchClientConfigurationTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchClientConfigurationTests.swift
@@ -6,7 +6,7 @@ class StitchClientConfigurationTests: XCTestCase {
     private let dataDirectory = URL.init(string: "foo/bar")!
     private let storage = MemoryStorage.init()
     private let transport = FoundationHTTPTransport.init()
-    private let transportTimeout: TimeInterval = defaultTestTransportTimeout
+    private let defaultRequestTimeout: TimeInterval = testDefaultRequestTimeout
 
     func testStitchClientConfigurationBuilderImplInit() throws {
         var builder = StitchClientConfigurationBuilderImpl { _ in }
@@ -41,16 +41,16 @@ class StitchClientConfigurationTests: XCTestCase {
         
         XCTAssertThrowsError(try builder.build()) { error in
             XCTAssertEqual(error as? StitchClientConfigurationError,
-                           StitchClientConfigurationError.missingTransportTimeout)
+                           StitchClientConfigurationError.missingDefaultRequestTimeout)
         }
         
-        builder.transportTimeout = self.transportTimeout
+        builder.defaultRequestTimeout = self.defaultRequestTimeout
 
         let config = try builder.build()
 
         XCTAssertEqual(config.baseURL, self.baseURL)
         XCTAssert(config.storage is MemoryStorage)
         XCTAssert(config.transport is FoundationHTTPTransport)
-        XCTAssertEqual(config.transportTimeout, self.transportTimeout)
+        XCTAssertEqual(config.defaultRequestTimeout, self.defaultRequestTimeout)
     }
 }

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchClientConfigurationTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/StitchClientConfigurationTests.swift
@@ -6,6 +6,7 @@ class StitchClientConfigurationTests: XCTestCase {
     private let dataDirectory = URL.init(string: "foo/bar")!
     private let storage = MemoryStorage.init()
     private let transport = FoundationHTTPTransport.init()
+    private let transportTimeout: TimeInterval = defaultTestTransportTimeout
 
     func testStitchClientConfigurationBuilderImplInit() throws {
         var builder = StitchClientConfigurationBuilderImpl { _ in }
@@ -37,11 +38,19 @@ class StitchClientConfigurationTests: XCTestCase {
         }
 
         builder.transport = self.transport
+        
+        XCTAssertThrowsError(try builder.build()) { error in
+            XCTAssertEqual(error as? StitchClientConfigurationError,
+                           StitchClientConfigurationError.missingTransportTimeout)
+        }
+        
+        builder.transportTimeout = self.transportTimeout
 
         let config = try builder.build()
 
         XCTAssertEqual(config.baseURL, self.baseURL)
         XCTAssert(config.storage is MemoryStorage)
         XCTAssert(config.transport is FoundationHTTPTransport)
+        XCTAssertEqual(config.transportTimeout, self.transportTimeout)
     }
 }

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/stitch_ios_sdk_protoTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/stitch_ios_sdk_protoTests.swift
@@ -62,7 +62,7 @@ public final class AtomicPort {
 
 let atomicPort = AtomicPort()
 
-let defaultTestTransportTimeout: TimeInterval = 15.0
+let testDefaultRequestTimeout: TimeInterval = 15.0
 
 private func start(server: HttpServer) -> UInt16 {
     repeat {

--- a/StitchCore/Tests/stitch-ios-sdk-protoTests/stitch_ios_sdk_protoTests.swift
+++ b/StitchCore/Tests/stitch-ios-sdk-protoTests/stitch_ios_sdk_protoTests.swift
@@ -62,6 +62,8 @@ public final class AtomicPort {
 
 let atomicPort = AtomicPort()
 
+let defaultTestTransportTimeout: TimeInterval = 15.0
+
 private func start(server: HttpServer) -> UInt16 {
     repeat {
         do {


### PR DESCRIPTION
This was pretty straightforward change, I added a transport timeout `TimeInterval` to client configuration, and I modified `doRequest` in the `StitchRequestClient` to perform the Transport round trip on a background dispatch queue, using the `DispatchGroup.wait(timeout:)` method to measure the timeout. 

I added a timeout test, updated the config tests, and also refactored the client initialization method in `Stitch.swift` to address a Swiftlint cyclomatic complexity violation that arose with the changes.