### PR TITLE
STITCH-1372 Implement AWS S3 service in Core and iOS

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -127,6 +127,8 @@ functions:
           sed -i -e 's/&lt;your-sid&gt;/${test_twilio_sid}/g' StitchCoreServicesTwilio-iOS/StitchCoreServicesTwilio-iOSTests/Info.plist
           sed -i -e 's/&lt;your-access-key-id&gt;/${test_aws_key}/g' StitchCoreServicesAwsSes-iOS/StitchCoreServicesAwsSes-iOSTests/Info.plist
           sed -i -e 's~&lt;your-secret-access-key&gt;~${test_aws_secret}~g' StitchCoreServicesAwsSes-iOS/StitchCoreServicesAwsSes-iOSTests/Info.plist
+          sed -i -e 's/&lt;your-access-key-id&gt;/${test_aws_key}/g' StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOSTests/Info.plist
+          sed -i -e 's~&lt;your-secret-access-key&gt;~${test_aws_secret}~g' StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOSTests/Info.plist
 tasks:
   - name: lint
     commands:
@@ -183,6 +185,8 @@ tasks:
             xcodebuild -workspace Stitch.xcworkspace/ -scheme StitchCoreServicesTwilio-Package -configuration Debug -derivedDataPath build -destination "platform=iOS Simulator,name=iPhone 7,OS=11.2"
             echo "!testing StitchCore-iOS!"
             xcodebuild test -workspace Stitch.xcworkspace/ -scheme StitchCore-iOS -configuration Debug -derivedDataPath build -destination "platform=iOS Simulator,name=iPhone 7,OS=11.2"
+            echo "!testing StitchCoreServicesAwsS3-iOS!"
+            xcodebuild test -workspace Stitch.xcworkspace/ -scheme StitchCoreServicesAwsS3-iOS -configuration Debug -derivedDataPath build -destination "platform=iOS Simulator,name=iPhone 7,OS=11.2"
             echo "!testing StitchCoreServicesAwsSes-iOS!"
             xcodebuild test -workspace Stitch.xcworkspace/ -scheme StitchCoreServicesAwsSes-iOS -configuration Debug -derivedDataPath build -destination "platform=iOS Simulator,name=iPhone 7,OS=11.2"
             echo "!testing StitchCoreServicesTwilio-iOS!"

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,12 @@ StitchCoreTestUtils/Package.resolved
 StitchCoreTestUtils/.build/
 StitchCoreTestUtils/*.xcodeproj/
 
+StitchCoreServicesAwsS3/Packages/
+StitchCoreServicesAwsS3/Package.pins
+StitchCoreServicesAwsS3/Package.resolved
+StitchCoreServicesAwsS3/.build/
+StitchCoreServicesAwsS3/StitchCoreServicesAwsS3.xcodeproj/
+
 StitchCoreServicesAwsSes/Packages/
 StitchCoreServicesAwsSes/Package.pins
 StitchCoreServicesAwsSes/Package.resolved

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all:
 	$(MAKE) -C StitchCore all
 	$(MAKE) -C StitchCoreAdminClient all
 	$(MAKE) -C StitchCoreTestUtils all
+	$(MAKE) -C StitchCoreServicesAwsS3 all
 	$(MAKE) -C StitchCoreServicesAwsSes all
 	$(MAKE) -C StitchCoreServicesTwilio all
 lint:
@@ -10,6 +11,7 @@ lint:
 	$(MAKE) -C StitchCore lint
 	$(MAKE) -C StitchCoreAdminClient lint
 	$(MAKE) -C StitchCoreTestUtils lint
+	$(MAKE) -C StitchCoreServicesAwsS3 lint
 	$(MAKE) -C StitchCoreServicesAwsSes lint
 	$(MAKE) -C StitchCoreServicesTwilio lint
 git:
@@ -17,6 +19,7 @@ git:
 	$(MAKE) -C StitchCore git
 	$(MAKE) -C StitchCoreAdminClient git
 	$(MAKE) -C StitchCoreTestUtils git
+	$(MAKE) -C StitchCoreServicesAwsS3 git
 	$(MAKE) -C StitchCoreServicesAwsSes git
 	$(MAKE) -C StitchCoreServicesTwilio git
 update:
@@ -24,6 +27,7 @@ update:
 	$(MAKE) -C StitchCore update
 	$(MAKE) -C StitchCoreAdminClient update
 	$(MAKE) -C StitchCoreTestUtils update
+	$(MAKE) -C StitchCoreServicesAwsS3 update
 	$(MAKE) -C StitchCoreServicesAwsSes update
 	$(MAKE) -C StitchCoreServicesTwilio update
 test:
@@ -31,6 +35,7 @@ test:
 	$(MAKE) -C StitchCore test
 	$(MAKE) -C StitchCoreAdminClient test
 	$(MAKE) -C StitchCoreTestUtils test
+	$(MAKE) -C StitchCoreServicesAwsS3 test
 	$(MAKE) -C StitchCoreServicesAwsSes test
 	$(MAKE) -C StitchCoreServicesTwilio test
 project:
@@ -38,5 +43,6 @@ project:
 	$(MAKE) -C StitchCore project
 	$(MAKE) -C StitchCoreAdminClient project
 	$(MAKE)	-C StitchCoreTestUtils project
-	$(MAKE) -C StitchCoreServicesAwsSes test
+	$(MAKE) -C StitchCoreServicesAwsS3 project
+	$(MAKE) -C StitchCoreServicesAwsSes project
 	$(MAKE) -C StitchCoreServicesTwilio project

--- a/Stitch.xcworkspace/contents.xcworkspacedata
+++ b/Stitch.xcworkspace/contents.xcworkspacedata
@@ -11,6 +11,9 @@
       location = "group:StitchCoreServicesAwsS3/StitchCoreServicesAwsS3.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:StitchCoreServicesAwsSes/StitchCoreServicesAwsSes.xcodeproj">
    </FileRef>
    <FileRef

--- a/Stitch.xcworkspace/contents.xcworkspacedata
+++ b/Stitch.xcworkspace/contents.xcworkspacedata
@@ -8,6 +8,9 @@
       location = "group:StitchSDKExample/StitchSDKExample.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:StitchCoreServicesAwsS3/StitchCoreServicesAwsS3.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:StitchCoreServicesAwsSes/StitchCoreServicesAwsSes.xcodeproj">
    </FileRef>
    <FileRef

--- a/StitchCoreAdminClient/Sources/StitchCoreAdminClient/Services/Rules/RulesResources.swift
+++ b/StitchCoreAdminClient/Sources/StitchCoreAdminClient/Services/Rules/RulesResources.swift
@@ -31,6 +31,11 @@ public struct RuleCreator: Encodable {
     }
 }
 
+/// Allowed actions for an AWS S3 service rule
+private struct AwsS3RuleActions: RuleActions {
+    let put, signPolicy: Bool
+}
+
 /// Allowed actions for an AWS SES service rule
 private struct AwsSesRuleActions: RuleActions {
     let send: Bool
@@ -56,6 +61,8 @@ public enum RuleActionsCreator: Encodable {
     case http(get: Bool, post: Bool, put: Bool, delete: Bool, patch: Bool, head: Bool)
     /// - parameter send: allow message sending
     case twilio(send: Bool)
+    /// - parameter putObject: allow object putting, signPolicy: allow policy signing
+    case awsS3(put: Bool, signPolicy: Bool)
     /// - parameter send: allow message sending
     case awsSes(send: Bool)
 
@@ -71,6 +78,8 @@ public enum RuleActionsCreator: Encodable {
                                      head: head).encode(to: encoder)
         case .twilio(let send):
             try TwilioRuleActions.init(send: send).encode(to: encoder)
+        case .awsS3(let put, let signPolicy):
+            try AwsS3RuleActions.init(put: put, signPolicy: signPolicy).encode(to: encoder)
         case .awsSes(let send):
             try AwsSesRuleActions.init(send: send).encode(to: encoder)
         }

--- a/StitchCoreAdminClient/Sources/StitchCoreAdminClient/Services/ServiceConfigs.swift
+++ b/StitchCoreAdminClient/Sources/StitchCoreAdminClient/Services/ServiceConfigs.swift
@@ -31,6 +31,24 @@ private struct HttpServiceConfig: ServiceConfig {
     }
 }
 
+/// Configuration for an AWS S3 service
+private struct AwsS3ServiceConfig: ServiceConfig {
+    /// aws region
+    private let region: String
+    /// your access key identifier
+    private let accessKeyId: String
+    /// your secret access key
+    private let secretAccessKey: String
+    
+    fileprivate init(region: String,
+                     accessKeyId: String,
+                     secretAccessKey: String) {
+        self.region = region
+        self.accessKeyId = accessKeyId
+        self.secretAccessKey = secretAccessKey
+    }
+}
+
 /// Configuration for an AWS SES service
 private struct AwsSesServiceConfig: ServiceConfig {
     /// aws region
@@ -73,6 +91,13 @@ public enum ServiceConfigs: Encodable {
     /// configure an http service
     /// - parameter name: name of this service
     case http(name: String)
+    
+    /// configure an AWS S3 service
+    /// - parameter name: name of this service
+    /// - parameter region: aws region
+    /// - parameter accessKeyId: your access key identifier
+    /// - parameter secretAccessKey: your secret access key
+    case awsS3(name: String, region: String, accessKeyId: String, secretAccessKey: String)
 
     /// configure an AWS SES service
     /// - parameter name: name of this service
@@ -97,6 +122,14 @@ public enum ServiceConfigs: Encodable {
                 type: "http",
                 config: HttpServiceConfig.init()
             ).encode(to: encoder)
+        case .awsS3(let name, let region, let accessKeyId, let secretAccessKey):
+            try ServiceConfigWrapper.init(
+                name: name,
+                type: "aws-s3",
+                config: AwsSesServiceConfig.init(region: region,
+                                                 accessKeyId: accessKeyId,
+                                                 secretAccessKey: secretAccessKey)
+                ).encode(to: encoder)
         case .awsSes(let name, let region, let accessKeyId, let secretAccessKey):
             try ServiceConfigWrapper.init(
                 name: name,

--- a/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS.xcodeproj/project.pbxproj
+++ b/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS.xcodeproj/project.pbxproj
@@ -1,0 +1,520 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		11405A7E20C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11405A7420C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.framework */; };
+		11405A8320C5A01E0041105B /* StitchCoreServicesAwsS3_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11405A8220C5A01E0041105B /* StitchCoreServicesAwsS3_iOSTests.swift */; };
+		11405A8520C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 11405A7720C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		11405A9020C5A0AC0041105B /* StitchCore_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11405A8F20C5A0AC0041105B /* StitchCore_iOS.framework */; };
+		11405A9220C5A0AC0041105B /* StitchCoreServicesAwsS3.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11405A9120C5A0AC0041105B /* StitchCoreServicesAwsS3.framework */; };
+		11405A9420C5A0CE0041105B /* StitchCoreTestUtils_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11405A9320C5A0CE0041105B /* StitchCoreTestUtils_iOS.framework */; };
+		11405A9620C5A0DF0041105B /* StitchCoreTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11405A9520C5A0DF0041105B /* StitchCoreTestUtils.framework */; };
+		11405A9820C5AF080041105B /* AwsS3ServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11405A9720C5AF080041105B /* AwsS3ServiceClient.swift */; };
+		11405A9B20C5AF230041105B /* AwsS3ServiceClientImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11405A9A20C5AF230041105B /* AwsS3ServiceClientImpl.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		11405A7F20C5A01E0041105B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 11405A6B20C5A01E0041105B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 11405A7320C5A01E0041105B;
+			remoteInfo = "StitchCoreServicesAwsS3-iOS";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		11405A7420C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StitchCoreServicesAwsS3_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		11405A7720C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StitchCoreServicesAwsS3_iOS.h; sourceTree = "<group>"; };
+		11405A7820C5A01E0041105B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		11405A7D20C5A01E0041105B /* StitchCoreServicesAwsS3-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "StitchCoreServicesAwsS3-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		11405A8220C5A01E0041105B /* StitchCoreServicesAwsS3_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchCoreServicesAwsS3_iOSTests.swift; sourceTree = "<group>"; };
+		11405A8420C5A01E0041105B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		11405A8F20C5A0AC0041105B /* StitchCore_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCore_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		11405A9120C5A0AC0041105B /* StitchCoreServicesAwsS3.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreServicesAwsS3.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		11405A9320C5A0CE0041105B /* StitchCoreTestUtils_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreTestUtils_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		11405A9520C5A0DF0041105B /* StitchCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		11405A9720C5AF080041105B /* AwsS3ServiceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwsS3ServiceClient.swift; sourceTree = "<group>"; };
+		11405A9A20C5AF230041105B /* AwsS3ServiceClientImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AwsS3ServiceClientImpl.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		11405A7020C5A01E0041105B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11405A9020C5A0AC0041105B /* StitchCore_iOS.framework in Frameworks */,
+				11405A9220C5A0AC0041105B /* StitchCoreServicesAwsS3.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		11405A7A20C5A01E0041105B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11405A9420C5A0CE0041105B /* StitchCoreTestUtils_iOS.framework in Frameworks */,
+				11405A9620C5A0DF0041105B /* StitchCoreTestUtils.framework in Frameworks */,
+				11405A7E20C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		11405A6A20C5A01E0041105B = {
+			isa = PBXGroup;
+			children = (
+				11405A7620C5A01E0041105B /* StitchCoreServicesAwsS3-iOS */,
+				11405A8120C5A01E0041105B /* StitchCoreServicesAwsS3-iOSTests */,
+				11405A7520C5A01E0041105B /* Products */,
+				11405A8E20C5A0AC0041105B /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		11405A7520C5A01E0041105B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				11405A7420C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.framework */,
+				11405A7D20C5A01E0041105B /* StitchCoreServicesAwsS3-iOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		11405A7620C5A01E0041105B /* StitchCoreServicesAwsS3-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				11405A9920C5AF140041105B /* Internal */,
+				11405A9720C5AF080041105B /* AwsS3ServiceClient.swift */,
+				11405A7720C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.h */,
+				11405A7820C5A01E0041105B /* Info.plist */,
+			);
+			path = "StitchCoreServicesAwsS3-iOS";
+			sourceTree = "<group>";
+		};
+		11405A8120C5A01E0041105B /* StitchCoreServicesAwsS3-iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				11405A8220C5A01E0041105B /* StitchCoreServicesAwsS3_iOSTests.swift */,
+				11405A8420C5A01E0041105B /* Info.plist */,
+			);
+			path = "StitchCoreServicesAwsS3-iOSTests";
+			sourceTree = "<group>";
+		};
+		11405A8E20C5A0AC0041105B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				11405A9520C5A0DF0041105B /* StitchCoreTestUtils.framework */,
+				11405A9320C5A0CE0041105B /* StitchCoreTestUtils_iOS.framework */,
+				11405A8F20C5A0AC0041105B /* StitchCore_iOS.framework */,
+				11405A9120C5A0AC0041105B /* StitchCoreServicesAwsS3.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		11405A9920C5AF140041105B /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				11405A9A20C5AF230041105B /* AwsS3ServiceClientImpl.swift */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		11405A7120C5A01E0041105B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11405A8520C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		11405A7320C5A01E0041105B /* StitchCoreServicesAwsS3-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 11405A8820C5A01E0041105B /* Build configuration list for PBXNativeTarget "StitchCoreServicesAwsS3-iOS" */;
+			buildPhases = (
+				11405A6F20C5A01E0041105B /* Sources */,
+				11405A7020C5A01E0041105B /* Frameworks */,
+				11405A7120C5A01E0041105B /* Headers */,
+				11405A7220C5A01E0041105B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "StitchCoreServicesAwsS3-iOS";
+			productName = "StitchCoreServicesAwsS3-iOS";
+			productReference = 11405A7420C5A01E0041105B /* StitchCoreServicesAwsS3_iOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		11405A7C20C5A01E0041105B /* StitchCoreServicesAwsS3-iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 11405A8B20C5A01E0041105B /* Build configuration list for PBXNativeTarget "StitchCoreServicesAwsS3-iOSTests" */;
+			buildPhases = (
+				11405A7920C5A01E0041105B /* Sources */,
+				11405A7A20C5A01E0041105B /* Frameworks */,
+				11405A7B20C5A01E0041105B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				11405A8020C5A01E0041105B /* PBXTargetDependency */,
+			);
+			name = "StitchCoreServicesAwsS3-iOSTests";
+			productName = "StitchCoreServicesAwsS3-iOSTests";
+			productReference = 11405A7D20C5A01E0041105B /* StitchCoreServicesAwsS3-iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		11405A6B20C5A01E0041105B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0930;
+				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = MongoDB;
+				TargetAttributes = {
+					11405A7320C5A01E0041105B = {
+						CreatedOnToolsVersion = 9.3.1;
+						LastSwiftMigration = 0930;
+					};
+					11405A7C20C5A01E0041105B = {
+						CreatedOnToolsVersion = 9.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 11405A6E20C5A01E0041105B /* Build configuration list for PBXProject "StitchCoreServicesAwsS3-iOS" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 11405A6A20C5A01E0041105B;
+			productRefGroup = 11405A7520C5A01E0041105B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				11405A7320C5A01E0041105B /* StitchCoreServicesAwsS3-iOS */,
+				11405A7C20C5A01E0041105B /* StitchCoreServicesAwsS3-iOSTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		11405A7220C5A01E0041105B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		11405A7B20C5A01E0041105B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		11405A6F20C5A01E0041105B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11405A9B20C5AF230041105B /* AwsS3ServiceClientImpl.swift in Sources */,
+				11405A9820C5AF080041105B /* AwsS3ServiceClient.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		11405A7920C5A01E0041105B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				11405A8320C5A01E0041105B /* StitchCoreServicesAwsS3_iOSTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		11405A8020C5A01E0041105B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 11405A7320C5A01E0041105B /* StitchCoreServicesAwsS3-iOS */;
+			targetProxy = 11405A7F20C5A01E0041105B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		11405A8620C5A01E0041105B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		11405A8720C5A01E0041105B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		11405A8920C5A01E0041105B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Sources/libbson",
+					"$(SRCROOT)/../Sources/libmongoc",
+				);
+				INFOPLIST_FILE = "StitchCoreServicesAwsS3-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../MobileSDKs/iphoneos/lib";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mongodb.StitchCoreServicesAwsS3-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		11405A8A20C5A01E0041105B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Sources/libbson",
+					"$(SRCROOT)/../Sources/libmongoc",
+				);
+				INFOPLIST_FILE = "StitchCoreServicesAwsS3-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../MobileSDKs/iphoneos/lib";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mongodb.StitchCoreServicesAwsS3-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		11405A8C20C5A01E0041105B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Sources/libbson",
+					"$(SRCROOT)/../Sources/libmongoc",
+				);
+				INFOPLIST_FILE = "StitchCoreServicesAwsS3-iOSTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../MobileSDKs/iphoneos/lib";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mongodb.StitchCoreServicesAwsS3-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		11405A8D20C5A01E0041105B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Sources/libbson",
+					"$(SRCROOT)/../Sources/libmongoc",
+				);
+				INFOPLIST_FILE = "StitchCoreServicesAwsS3-iOSTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../MobileSDKs/iphoneos/lib";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mongodb.StitchCoreServicesAwsS3-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		11405A6E20C5A01E0041105B /* Build configuration list for PBXProject "StitchCoreServicesAwsS3-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				11405A8620C5A01E0041105B /* Debug */,
+				11405A8720C5A01E0041105B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		11405A8820C5A01E0041105B /* Build configuration list for PBXNativeTarget "StitchCoreServicesAwsS3-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				11405A8920C5A01E0041105B /* Debug */,
+				11405A8A20C5A01E0041105B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		11405A8B20C5A01E0041105B /* Build configuration list for PBXNativeTarget "StitchCoreServicesAwsS3-iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				11405A8C20C5A01E0041105B /* Debug */,
+				11405A8D20C5A01E0041105B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 11405A6B20C5A01E0041105B /* Project object */;
+}

--- a/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS/AwsS3ServiceClient.swift
+++ b/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS/AwsS3ServiceClient.swift
@@ -1,0 +1,175 @@
+import Foundation
+import MongoSwift
+import StitchCore
+import StitchCore_iOS
+import StitchCoreServicesAwsS3
+
+private final class AwsS3NamedServiceClientFactory: NamedServiceClientFactory {
+    typealias ClientType = AwsS3ServiceClient
+    
+    func client(withServiceClient serviceClient: StitchServiceClient,
+                withClientInfo clientInfo: StitchAppClientInfo) -> AwsS3ServiceClient {
+        return AwsS3ServiceClientImpl(
+            withClient: CoreAwsS3ServiceClient.init(withService: serviceClient),
+            withDispatcher: OperationDispatcher(withDispatchQueue: DispatchQueue.global())
+        )
+    }
+}
+
+public protocol AwsS3ServiceClient {
+    /**
+     * Puts an object into an AWS S3 bucket as a string.
+     *
+     * - parameters:
+     *     - bucket: the bucket to put the object in
+     *     - key: the key (or name) of the object
+     *     - acl: the ACL to apply to the object (e.g. private)
+     *     - contentType: the content type of the object (e.g. "application/json")
+     *     - body: the body of the object as a string
+     *     - completionHandler: The completion handler to call when the object is put or the operation fails.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     */
+    func putObject(
+        bucket: String,
+        key: String,
+        acl: String,
+        contentType: String,
+        body: String,
+        _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void)
+    
+    /**
+     * Puts an object into an AWS S3 bucket as a string. A timeout can be specified if the operation is expected to
+     * take longer than the default timeout configured for the Stitch app client.
+     *
+     * - parameters:
+     *     - bucket: the bucket to put the object in
+     *     - key: the key (or name) of the object
+     *     - acl: the ACL to apply to the object (e.g. private)
+     *     - contentType: the content type of the object (e.g. "application/json")
+     *     - body: the body of the object as a string
+     *     - timeout: the number of seconds to wait for the put request to complete before timing out
+     *     - completionHandler: The completion handler to call when the object is put or the operation fails.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     */
+    func putObject(
+        bucket: String,
+        key: String,
+        acl: String,
+        contentType: String,
+        body: String,
+        timeout: TimeInterval,
+        _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void)
+    
+    /**
+     * Puts a binary object into an AWS S3 bucket as a Foundation `Data` object.
+     *
+     * - parameters:
+     *     - bucket: the bucket to put the object in
+     *     - key: the key (or name) of the object
+     *     - acl: the ACL to apply to the object (e.g. private)
+     *     - contentType: the content type of the object (e.g. "application/json")
+     *     - body: the body of the object as a `Data`
+     *     - completionHandler: The completion handler to call when the object is put or the operation fails.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     */
+    func putObject(
+        bucket: String,
+        key: String,
+        acl: String,
+        contentType: String,
+        body: Data,
+        _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void)
+    
+    /**
+     * Puts an object into an AWS S3 bucket as a Foundation `Data` object.. A timeout can be specified if the operation
+     * is expected to take longer than the default timeout configured for the Stitch app client.
+     *
+     * - parameters:
+     *     - bucket: the bucket to put the object in
+     *     - key: the key (or name) of the object
+     *     - acl: the ACL to apply to the object (e.g. private)
+     *     - contentType: the content type of the object (e.g. "application/json")
+     *     - body: the body of the object as a `Data`
+     *     - timeout: the number of seconds to wait for the put request to complete before timing out
+     *     - completionHandler: The completion handler to call when the object is put or the operation fails.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     */
+    func putObject(
+        bucket: String,
+        key: String,
+        acl: String,
+        contentType: String,
+        body: Data,
+        timeout: TimeInterval,
+        _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void)
+    
+    /**
+     * Puts a binary object into an AWS S3 bucket as a BSON `Binary` object.
+     *
+     * - parameters:
+     *     - bucket: the bucket to put the object in
+     *     - key: the key (or name) of the object
+     *     - acl: the ACL to apply to the object (e.g. private)
+     *     - contentType: the content type of the object (e.g. "application/json")
+     *     - body: the body of the object as a BSON `Binary`
+     *     - completionHandler: The completion handler to call when the object is put or the operation fails.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     */
+    func putObject(
+        bucket: String,
+        key: String,
+        acl: String,
+        contentType: String,
+        body: Binary,
+        _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void)
+    
+    /**
+     * Puts an object into an AWS S3 bucket as a BSON `Binary` object. A timeout can be specified if the operation
+     * is expected to take longer than the default timeout configured for the Stitch app client.
+     *
+     * - parameters:
+     *     - bucket: the bucket to put the object in
+     *     - key: the key (or name) of the object
+     *     - acl: the ACL to apply to the object (e.g. private)
+     *     - contentType: the content type of the object (e.g. "application/json")
+     *     - body: the body of the object as a BSON `Binary`
+     *     - timeout: the number of seconds to wait for the put request to complete before timing out
+     *     - completionHandler: The completion handler to call when the object is put or the operation fails.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     */
+    func putObject(
+        bucket: String,
+        key: String,
+        acl: String,
+        contentType: String,
+        body: Binary,
+        timeout: TimeInterval,
+        _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void)
+    
+    /**
+     * Signs an AWS S3 security policy for a future put object request. This future request would
+     * be made outside of the Stitch SDK. This is typically used for large requests that are better
+     * sent directly to AWS.
+     *
+     * - seealso:
+     * [Uploading a File to Amazon S3 Using HTTP POST]
+     * (https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html)
+     *
+     * - parameters:
+     *     - bucket: the bucket to put the object in
+     *     - key: the key (or name) of the object
+     *     - acl: the ACL to apply to the object (e.g. private)
+     *     - contentType: the content type of the object (e.g. "application/json")
+     */
+    func signPolicy(bucket: String,
+                    key: String,
+                    acl: String,
+                    contentType: String,
+                    _ completionHandler: @escaping (AwsS3SignPolicyResult?, Error?) -> Void)
+}
+
+public final class AwsS3Service {
+    public static let sharedFactory = AnyNamedServiceClientFactory<AwsS3ServiceClient>(
+        factory: AwsS3NamedServiceClientFactory()
+    )
+}

--- a/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS/Info.plist
+++ b/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS/Internal/AwsS3ServiceClientImpl.swift
+++ b/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS/Internal/AwsS3ServiceClientImpl.swift
@@ -1,0 +1,139 @@
+import Foundation
+import MongoSwift
+import StitchCore
+import StitchCore_iOS
+import StitchCoreServicesAwsS3
+
+public final class AwsS3ServiceClientImpl: AwsS3ServiceClient {
+    private let proxy: CoreAwsS3ServiceClient
+    private let dispatcher: OperationDispatcher
+    
+    internal init(withClient client: CoreAwsS3ServiceClient,
+                  withDispatcher dispatcher: OperationDispatcher) {
+        self.proxy = client
+        self.dispatcher = dispatcher
+    }
+    
+    public func putObject(bucket: String,
+                          key: String,
+                          acl: String,
+                          contentType: String,
+                          body: String,
+                          _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void) {
+        self.dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.proxy.putObject(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType,
+                body: body
+            )
+        }
+    }
+    
+    public func putObject(bucket: String,
+                          key: String,
+                          acl: String,
+                          contentType: String,
+                          body: String,
+                          timeout: TimeInterval,
+                          _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void) {
+        self.dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.proxy.putObject(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType,
+                body: body,
+                timeout: timeout
+            )
+        }
+    }
+    
+    public func putObject(bucket: String,
+                          key: String,
+                          acl: String,
+                          contentType: String,
+                          body: Data,
+                          _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void) {
+        self.dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.proxy.putObject(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType,
+                body: body
+            )
+        }
+    }
+    
+    public func putObject(bucket: String,
+                          key: String,
+                          acl: String,
+                          contentType: String,
+                          body: Data,
+                          timeout: TimeInterval,
+                          _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void) {
+        self.dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.proxy.putObject(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType,
+                body: body,
+                timeout: timeout
+            )
+        }
+    }
+    
+    public func putObject(bucket: String,
+                          key: String,
+                          acl: String,
+                          contentType: String,
+                          body: Binary,
+                          _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void) {
+        self.dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.proxy.putObject(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType,
+                body: body
+            )
+        }
+    }
+    
+    public func putObject(bucket: String,
+                          key: String,
+                          acl: String,
+                          contentType: String,
+                          body: Binary,
+                          timeout: TimeInterval,
+                          _ completionHandler: @escaping (AwsS3PutObjectResult?, Error?) -> Void) {
+        self.dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.proxy.putObject(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType,
+                body: body,
+                timeout: timeout
+            )
+        }
+    }
+    
+    public func signPolicy(bucket: String,
+                           key: String,
+                           acl: String,
+                           contentType: String,
+                           _ completionHandler: @escaping (AwsS3SignPolicyResult?, Error?) -> Void) {
+        self.dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.proxy.signPolicy(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType
+            )
+        }
+    }
+}

--- a/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3_iOS.h
+++ b/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3_iOS.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+//! Project version number for StitchCoreServicesAwsS3_iOS.
+FOUNDATION_EXPORT double StitchCoreServicesAwsS3_iOSVersionNumber;
+
+//! Project version string for StitchCoreServicesAwsS3_iOS.
+FOUNDATION_EXPORT const unsigned char StitchCoreServicesAwsS3_iOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <StitchCoreServicesAwsS3_iOS/PublicHeader.h>

--- a/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOSTests/Info.plist
+++ b/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOSTests/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>test.stitch.secretAccessKey</key>
+	<string>&lt;your-secret-access-key&gt;</string>
+	<key>test.stitch.accessKeyId</key>
+	<string>&lt;your-access-key-id&gt;</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOSTests/StitchCoreServicesAwsS3_iOSTests.swift
+++ b/StitchCoreServicesAwsS3-iOS/StitchCoreServicesAwsS3-iOSTests/StitchCoreServicesAwsS3_iOSTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+import MongoSwift
+import StitchCore
+import StitchCoreAdminClient
+import StitchCoreTestUtils_iOS
+import StitchCoreServicesAwsS3
+@testable import StitchCoreServicesAwsS3_iOS
+
+class StitchCoreServicesAwsS3_iOSTests: BaseStitchIntTestCocoaTouch {
+    private let awsAccessKeyIdProp = "test.stitch.accessKeyId"
+    private let awsSecretAccessKeyProp = "test.stitch.secretAccessKey"
+    
+    private lazy var pList: [String: Any]? = fetchPlist(type(of: self))
+    
+    private lazy var awsAccessKeyId: String? = pList?[awsAccessKeyIdProp] as? String
+    private lazy var awsSecretAccessKey: String? = pList?[awsSecretAccessKeyProp] as? String
+    
+    override func setUp() {
+        super.setUp()
+        
+        guard awsAccessKeyId != nil && awsAccessKeyId != "<your-access-key-id>",
+            awsSecretAccessKey != nil && awsSecretAccessKey != "<your-secret-access-key>" else {
+                XCTFail("No AWS Access Key ID, or Secret Access Key in properties; failing test. See README for more details.")
+                return
+        }
+    }
+
+    func testPutObject() throws {
+        let app = try self.createApp()
+        let _ = try self.addProvider(toApp: app.1, withConfig: ProviderConfigs.anon())
+        let svc = try self.addService(
+            toApp: app.1,
+            withType: "aws-s3",
+            withName: "aws-s31",
+            withConfig: ServiceConfigs.awsS3(
+                name: "aws-s31",
+                region: "us-east-1", accessKeyId: awsAccessKeyId!, secretAccessKey: awsSecretAccessKey!
+            )
+        )
+        _ = try self.addRule(toService: svc.1,
+                             withConfig: RuleCreator.init(
+                                name: "rule",
+                                actions: RuleActionsCreator.awsS3(put: true, signPolicy: true)))
+        
+        let client = try self.appClient(forApp: app.0)
+        
+        let exp0 = expectation(description: "should login")
+        client.auth.login(withCredential: AnonymousCredential()) { _,_  in
+            exp0.fulfill()
+        }
+        wait(for: [exp0], timeout: 5.0)
+        
+        let awsS3 = client.serviceClient(forFactory: AwsS3Service.sharedFactory, withName: "aws-s31")
+        
+        // Putting to an bad bucket should fail
+        let bucket = "notmystuff"
+        let key = ObjectId.init().description
+        let acl = "public-read"
+        let contentType = "plain/text"
+        let body = "hello again friend; did you miss me"
+        
+        let exp1 = expectation(description: "should not put object")
+        awsS3.putObject(bucket: bucket, key: key, acl: acl, contentType: contentType, body: body) { (_, error) in
+            switch error as? StitchError {
+            case .serviceError(_, let withServiceErrorCode)?:
+                XCTAssertEqual(StitchServiceErrorCode.awsError, withServiceErrorCode)
+            default:
+                XCTFail()
+            }
+            exp1.fulfill()
+        }
+        wait(for: [exp1], timeout: 5.0)
+        
+        // Putting with all good params for S3 should work
+        let bucketGood = "stitch-test-sdkfiles"
+        let expectedLocation = "https://stitch-test-sdkfiles.s3.amazonaws.com/\(key)"
+        let transport = FoundationHTTPTransport()
+        
+        let exp2 = expectation(description: "should put BSON binary")
+        awsS3.putObject(bucket: bucketGood, key: key, acl: acl, contentType: contentType, body: body) { (result, _) in
+            XCTAssertNotNil(result)
+            
+            XCTAssertEqual(expectedLocation, result?.location)
+            exp2.fulfill()
+        }
+        wait(for: [exp2], timeout: 5.0)
+        
+        var httpResult = try transport.roundTrip(request: RequestBuilder()
+            .with(method: .get)
+            .with(url: expectedLocation)
+            .with(timeout: 1.5)
+            .build()
+        )
+        
+        XCTAssertEqual(body, String.init(data: httpResult.body!, encoding: .utf8))
+        
+        // ...with BSON binary parameter
+        let bodyBin = Binary(data: body.data(using: .utf8)!, subtype: .binary)
+        
+        let exp3 = expectation(description: "should put string")
+        awsS3.putObject(bucket: bucketGood, key: key, acl: acl, contentType: contentType, body: bodyBin) { (result, _) in
+            XCTAssertNotNil(result)
+            
+            XCTAssertEqual(expectedLocation, result?.location)
+            exp3.fulfill()
+        }
+        wait(for: [exp3], timeout: 5.0)
+        
+        httpResult = try transport.roundTrip(request: RequestBuilder()
+            .with(method: .get)
+            .with(url: expectedLocation)
+            .with(timeout: 1.5)
+            .build()
+        )
+        
+        XCTAssertEqual(bodyBin.data, httpResult.body!)
+        
+        // ...with Foundation Data parameter
+        let bodyData = body.data(using: .utf8)!
+        
+        let exp4 = expectation(description: "should put Foundation Data")
+        awsS3.putObject(bucket: bucketGood, key: key, acl: acl, contentType: contentType, body: bodyData) { (result, _) in
+            XCTAssertNotNil(result)
+            
+            XCTAssertEqual(expectedLocation, result?.location)
+            exp4.fulfill()
+        }
+        wait(for: [exp4], timeout: 5.0)
+        
+        httpResult = try transport.roundTrip(request: RequestBuilder()
+            .with(method: .get)
+            .with(url: expectedLocation)
+            .with(timeout: 1.5)
+            .build()
+        )
+        
+        XCTAssertEqual(bodyData, httpResult.body!)
+        
+        // Excluding any required parameters should fail
+        let exp5 = expectation(description: "should not put object")
+        awsS3.putObject(bucket: "", key: key, acl: acl, contentType: contentType, body: body) { (_, error) in
+            switch error as? StitchError {
+            case .serviceError(_, let withServiceErrorCode)?:
+                XCTAssertEqual(StitchServiceErrorCode.invalidParameter, withServiceErrorCode)
+            default:
+                XCTFail()
+            }
+            exp5.fulfill()
+        }
+        wait(for: [exp5], timeout: 5.0)
+    }
+    
+    func testSignPolicy() throws {
+        let app = try self.createApp()
+        let _ = try self.addProvider(toApp: app.1, withConfig: ProviderConfigs.anon())
+        let svc = try self.addService(
+            toApp: app.1,
+            withType: "aws-s3",
+            withName: "aws-s31",
+            withConfig: ServiceConfigs.awsS3(
+                name: "aws-s31",
+                region: "us-east-1", accessKeyId: awsAccessKeyId!, secretAccessKey: awsSecretAccessKey!
+            )
+        )
+        _ = try self.addRule(toService: svc.1,
+                             withConfig: RuleCreator.init(
+                                name: "rule",
+                                actions: RuleActionsCreator.awsS3(put: true, signPolicy: true)))
+        
+        let client = try self.appClient(forApp: app.0)
+        
+        let exp0 = expectation(description: "should login")
+        client.auth.login(withCredential: AnonymousCredential()) { _,_  in
+            exp0.fulfill()
+        }
+        wait(for: [exp0], timeout: 5.0)
+        
+        let awsS3 = client.serviceClient(forFactory: AwsS3Service.sharedFactory, withName: "aws-s31")
+        
+        // Including all parameters should succeed
+        let bucket = "notmystuff"
+        let key = ObjectId.init().description
+        let acl = "public-read"
+        let contentType = "plain/text"
+        
+        let exp1 = expectation(description: "should sign policy")
+        awsS3.signPolicy(bucket: bucket, key: key, acl: acl, contentType: contentType) { (result, _) in
+            XCTAssertNotNil(result)
+            
+            XCTAssertFalse(result!.algorithm.isEmpty)
+            XCTAssertFalse(result!.credential.isEmpty)
+            XCTAssertFalse(result!.date.isEmpty)
+            XCTAssertFalse(result!.policy.isEmpty)
+            XCTAssertFalse(result!.signature.isEmpty)
+            exp1.fulfill()
+        }
+        wait(for: [exp1], timeout: 5.0)
+        
+        // Excluding any required parameters should fail
+        let exp2 = expectation(description: "should not sign policy")
+        awsS3.signPolicy(bucket: "", key: key, acl: acl, contentType: contentType) { (_, error) in
+            switch error as? StitchError {
+            case .serviceError(_, let withServiceErrorCode)?:
+                XCTAssertEqual(StitchServiceErrorCode.invalidParameter, withServiceErrorCode)
+            default:
+                XCTFail()
+            }
+            exp2.fulfill()
+        }
+        wait(for: [exp2], timeout: 5.0)
+    }
+    
+}

--- a/StitchCoreServicesAwsS3/.gitignore
+++ b/StitchCoreServicesAwsS3/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/StitchCoreServicesAwsS3/Makefile
+++ b/StitchCoreServicesAwsS3/Makefile
@@ -1,0 +1,18 @@
+all: git clean update project build
+git:
+	git init
+	git add .
+	git commit --allow-empty -m "init"
+lint:
+	swiftlint
+clean:
+	swift package clean
+build:
+	swift build -Xcc -I../MobileSDKs/include/libbson-1.0/ -Xcc -I../MobileSDKs/include/libmongoc-1.0
+update:
+	swift package update
+test:
+	# temporary until a fix is in for .brew dependency for libmongoc
+	xcodebuild test -workspace ../Stitch.xcworkspace/ -scheme StitchCoreServicesAwsS3-Package -configuration Debug -destination "platform=iOS Simulator,name=iPhone 7,OS=11.2"
+project:
+	swift package generate-xcodeproj --xcconfig-overrides StitchCoreServicesAwsS3.xcconfig

--- a/StitchCoreServicesAwsS3/Package.swift
+++ b/StitchCoreServicesAwsS3/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "StitchCoreServicesAwsS3",
+    products: [
+        .library(
+            name: "StitchCoreServicesAwsS3",
+            targets: ["StitchCoreServicesAwsS3"]),
+    ],
+    dependencies: [
+        .package(url: "../StitchCore", .branch("master"))
+    ],
+    targets: [
+        .target(
+            name: "StitchCoreServicesAwsS3",
+            dependencies: ["StitchCore"]),
+        .testTarget(
+            name: "StitchCoreServicesAwsS3Tests",
+            dependencies: ["StitchCoreServicesAwsS3", "StitchCoreMocks"]),
+    ]
+)

--- a/StitchCoreServicesAwsS3/README.md
+++ b/StitchCoreServicesAwsS3/README.md
@@ -1,0 +1,3 @@
+# StitchCoreServicesAwsS3
+
+A description of this package.

--- a/StitchCoreServicesAwsS3/Sources/StitchCoreServicesAwsS3/AwsS3PutObjectResult.swift
+++ b/StitchCoreServicesAwsS3/Sources/StitchCoreServicesAwsS3/AwsS3PutObjectResult.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/**
+ * The result of an AWS S3 put object request.
+ */
+public struct AwsS3PutObjectResult: Decodable {
+    /**
+     * The location of the object.
+     */
+    public let location: String
+}

--- a/StitchCoreServicesAwsS3/Sources/StitchCoreServicesAwsS3/AwsS3SignPolicyResult.swift
+++ b/StitchCoreServicesAwsS3/Sources/StitchCoreServicesAwsS3/AwsS3SignPolicyResult.swift
@@ -7,7 +7,7 @@ public struct AwsS3SignPolicyResult: Decodable {
     /**
      * The description of the policy that has been signed.
      */
-    public let description: String
+    public let policy: String
     
     /**
      * The computed signature of the policy.

--- a/StitchCoreServicesAwsS3/Sources/StitchCoreServicesAwsS3/AwsS3SignPolicyResult.swift
+++ b/StitchCoreServicesAwsS3/Sources/StitchCoreServicesAwsS3/AwsS3SignPolicyResult.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/**
+ * The result of an AWS S3 sign policy request.
+ */
+public struct AwsS3SignPolicyResult: Decodable {
+    /**
+     * The description of the policy that has been signed.
+     */
+    public let description: String
+    
+    /**
+     * The computed signature of the policy.
+     */
+    public let signature: String
+    
+    /**
+     * The algorithm used to compute the signature.
+     */
+    public let algorithm: String
+    
+    /**
+     * The date at which the signature was computed.
+     */
+    public let date: String
+    
+    /**
+     * The credential that should be used when utilizing this signed policy.
+     */
+    public let credential: String
+}

--- a/StitchCoreServicesAwsS3/StitchCoreServicesAwsS3.xcconfig
+++ b/StitchCoreServicesAwsS3/StitchCoreServicesAwsS3.xcconfig
@@ -1,0 +1,21 @@
+//
+// StitchCore.xcconfig
+//
+
+OTHER_LDFLAGS[sdk=iphoneos*] = -rpath $(SRCROOT)/../MobileSDKs/iphoneos/lib
+OTHER_LDFLAGS[sdk=iphonesimulator*] = -rpath $(SRCROOT)/../MobileSDKs/iphoneos/lib
+OTHER_LDFLAGS[sdk=appletvos*] = -rpath $(SRCROOT)/../MobileSDKs/appletvos/lib
+OTHER_LDFLAGS[sdk=appletvsimulator*] = -rpath $(SRCROOT)/../MobileSDKs/appletvos/lib
+LIBRARY_SEARCH_PATHS[sdk=iphoneos*]        = $(SRCROOT)/../MobileSDKs/iphoneos/lib
+LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*] = $(SRCROOT)/../MobileSDKs/iphoneos/lib
+LIBRARY_SEARCH_PATHS[sdk=appletvos*]       = $(SRCROOT)/../MobileSDKs/appletvos/lib
+LIBRARY_SEARCH_PATHS[sdk=appletvsimulator*] = $(SRCROOT)/../MobileSDKs/appletvos/lib
+
+SWIFT_INCLUDE_PATHS = $(SRCROOT)/../MobileSDKs/include $(SRCROOT)/../MobileSDKs/include/libbson-1.0 $(SRCROOT)/../MobileSDKs/include/libmongoc-1.0
+
+ENABLE_BITCODE = NO
+
+IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos*]=8.0
+IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator*]=8.0
+IPHONEOS_DEPLOYMENT_TARGET[sdk=appletvos*]=8.0
+IPHONEOS_DEPLOYMENT_TARGET[sdk=appletvsimulator*]=8.0

--- a/StitchCoreServicesAwsS3/Tests/StitchCoreServicesAwsS3Tests/CoreAwsS3ServiceClientTests.swift
+++ b/StitchCoreServicesAwsS3/Tests/StitchCoreServicesAwsS3Tests/CoreAwsS3ServiceClientTests.swift
@@ -1,0 +1,273 @@
+import XCTest
+import MockUtils
+import MongoSwift
+import StitchCore
+import StitchCoreMocks
+@testable import StitchCoreServicesAwsS3
+
+final class CoreAwsS3ServiceClientTests: XCTestCase {
+    func testPutObjectString() throws {
+        let service = MockCoreStitchService()
+        let client = CoreAwsS3ServiceClient(withService: service)
+        
+        let bucket = "stuff"
+        let key = "myFile"
+        let acl = "public-read"
+        let contentType = "plain/text"
+        let body = "some data yo"
+        
+        let expectedLocation = "awsLocation"
+        
+        service.callFunctionInternalWithDecodingMock.doReturn(
+            result: AwsS3PutObjectResult.init(location: expectedLocation),
+            forArg1: .any,
+            forArg2: .any,
+            forArg3: .any
+        )
+        
+        let result = try client.putObject(
+            bucket: bucket,
+            key: key,
+            acl: acl,
+            contentType: contentType,
+            body: body
+        )
+        
+        XCTAssertEqual(expectedLocation, result.location)
+        
+        let (funcNameArg, funcArgsArg, _) = service.callFunctionInternalWithDecodingMock.capturedInvocations.last!
+        
+        XCTAssertEqual("put", funcNameArg)
+        XCTAssertEqual(1, funcArgsArg.count)
+        
+        let expectedArgs: Document = [
+            "bucket": bucket,
+            "key": key,
+            "acl": acl,
+            "contentType": contentType,
+            "body": body
+        ]
+        
+        XCTAssertEqual(expectedArgs, funcArgsArg[0] as? Document)
+        
+        // should pass along errors
+        service.callFunctionInternalWithDecodingMock.doThrow(
+            error: StitchError.serviceError(withMessage: "", withServiceErrorCode: .unknown),
+            forArg1: .any,
+            forArg2: .any,
+            forArg3: .any
+        )
+        
+        do {
+            _ = try client.putObject(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType,
+                body: body
+            )
+            XCTFail("function did not fail where expected")
+        } catch {
+            // do nothing
+        }
+    }
+    
+    func testPutObjectBinary() throws {
+        let service = MockCoreStitchService()
+        let client = CoreAwsS3ServiceClient(withService: service)
+        
+        let bucket = "stuff"
+        let key = "myFile"
+        let acl = "public-read"
+        let contentType = "plain/text"
+        let body = Binary.init(data: "some data yo".data(using: .utf8)!, subtype: .binary)
+        
+        let expectedLocation = "awsLocation"
+        
+        service.callFunctionInternalWithDecodingMock.doReturn(
+            result: AwsS3PutObjectResult.init(location: expectedLocation),
+            forArg1: .any,
+            forArg2: .any,
+            forArg3: .any
+        )
+        
+        let result = try client.putObject(
+            bucket: bucket,
+            key: key,
+            acl: acl,
+            contentType: contentType,
+            body: body
+        )
+        
+        XCTAssertEqual(expectedLocation, result.location)
+        
+        let (funcNameArg, funcArgsArg, _) = service.callFunctionInternalWithDecodingMock.capturedInvocations.last!
+        
+        XCTAssertEqual("put", funcNameArg)
+        XCTAssertEqual(1, funcArgsArg.count)
+        
+        let expectedArgs: Document = [
+            "bucket": bucket,
+            "key": key,
+            "acl": acl,
+            "contentType": contentType,
+            "body": body
+        ]
+        
+        XCTAssertEqual(expectedArgs, funcArgsArg[0] as? Document)
+        
+        // should pass along errors
+        service.callFunctionInternalWithDecodingMock.doThrow(
+            error: StitchError.serviceError(withMessage: "", withServiceErrorCode: .unknown),
+            forArg1: .any,
+            forArg2: .any,
+            forArg3: .any
+        )
+        
+        do {
+            _ = try client.putObject(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType,
+                body: body
+            )
+            XCTFail("function did not fail where expected")
+        } catch {
+            // do nothing
+        }
+    }
+    
+    func testPutObjectData() throws {
+        let service = MockCoreStitchService()
+        let client = CoreAwsS3ServiceClient(withService: service)
+        
+        let bucket = "stuff"
+        let key = "myFile"
+        let acl = "public-read"
+        let contentType = "plain/text"
+        let body = "some data yo".data(using: .utf8)!
+        
+        let expectedLocation = "awsLocation"
+        
+        service.callFunctionInternalWithDecodingMock.doReturn(
+            result: AwsS3PutObjectResult.init(location: expectedLocation),
+            forArg1: .any,
+            forArg2: .any,
+            forArg3: .any
+        )
+        
+        let result = try client.putObject(
+            bucket: bucket,
+            key: key,
+            acl: acl,
+            contentType: contentType,
+            body: body
+        )
+        
+        XCTAssertEqual(expectedLocation, result.location)
+        
+        let (funcNameArg, funcArgsArg, _) = service.callFunctionInternalWithDecodingMock.capturedInvocations.last!
+        
+        XCTAssertEqual("put", funcNameArg)
+        XCTAssertEqual(1, funcArgsArg.count)
+        
+        let expectedArgs: Document = [
+            "bucket": bucket,
+            "key": key,
+            "acl": acl,
+            "contentType": contentType,
+            "body": Binary.init(data: body, subtype: .binary)
+        ]
+        
+        XCTAssertEqual(expectedArgs, funcArgsArg[0] as? Document)
+        
+        // should pass along errors
+        service.callFunctionInternalWithDecodingMock.doThrow(
+            error: StitchError.serviceError(withMessage: "", withServiceErrorCode: .unknown),
+            forArg1: .any,
+            forArg2: .any,
+            forArg3: .any
+        )
+        
+        do {
+            _ = try client.putObject(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType,
+                body: body
+            )
+            XCTFail("function did not fail where expected")
+        } catch {
+            // do nothing
+        }
+    }
+    
+    func testSignPolicy() throws {
+        let service = MockCoreStitchService()
+        let client = CoreAwsS3ServiceClient(withService: service)
+        
+        let bucket = "stuff"
+        let key = "myFile"
+        let acl = "public-read"
+        let contentType = "plain/text"
+        
+        let expectedPolicy = "you shall not"
+        let expectedSignature = "yoursTruly"
+        let expectedAlgorithm = "DES-111"
+        let expectedDate = "01-101-2012"
+        let expectedCredential = "someCredential"
+        
+        service.callFunctionInternalWithDecodingMock.doReturn(
+            result: AwsS3SignPolicyResult.init(description: expectedPolicy,
+                                               signature: expectedSignature,
+                                               algorithm: expectedAlgorithm,
+                                               date: expectedDate,
+                                               credential: expectedCredential),
+            forArg1: .any, forArg2: .any, forArg3: .any
+        )
+        
+        let result = try client.signPolicy(bucket: bucket, key: key, acl: acl, contentType: contentType)
+        
+        XCTAssertEqual(expectedPolicy, result.description)
+        XCTAssertEqual(expectedSignature, result.signature)
+        XCTAssertEqual(expectedAlgorithm, result.algorithm)
+        XCTAssertEqual(expectedDate, result.date)
+        XCTAssertEqual(expectedCredential, result.credential)
+        
+        let (funcNameArg, funcArgsArg, _) = service.callFunctionInternalWithDecodingMock.capturedInvocations.last!
+        
+        XCTAssertEqual("signPolicy", funcNameArg)
+        XCTAssertEqual(1, funcArgsArg.count)
+        
+        let expectedArgs: Document = [
+            "bucket": bucket,
+            "key": key,
+            "acl": acl,
+            "contentType": contentType
+        ]
+        
+        XCTAssertEqual(expectedArgs, funcArgsArg[0] as? Document)
+        
+        // should pass along errors
+        service.callFunctionInternalWithDecodingMock.doThrow(
+            error: StitchError.serviceError(withMessage: "", withServiceErrorCode: .unknown),
+            forArg1: .any,
+            forArg2: .any,
+            forArg3: .any
+        )
+        
+        do {
+            _ = try client.signPolicy(
+                bucket: bucket,
+                key: key,
+                acl: acl,
+                contentType: contentType
+            )
+            XCTFail("function did not fail where expected")
+        } catch {
+            // do nothing
+        }
+    }
+}

--- a/StitchCoreServicesAwsS3/Tests/StitchCoreServicesAwsS3Tests/CoreAwsS3ServiceClientTests.swift
+++ b/StitchCoreServicesAwsS3/Tests/StitchCoreServicesAwsS3Tests/CoreAwsS3ServiceClientTests.swift
@@ -220,7 +220,7 @@ final class CoreAwsS3ServiceClientTests: XCTestCase {
         let expectedCredential = "someCredential"
         
         service.callFunctionInternalWithDecodingMock.doReturn(
-            result: AwsS3SignPolicyResult.init(description: expectedPolicy,
+            result: AwsS3SignPolicyResult.init(policy: expectedPolicy,
                                                signature: expectedSignature,
                                                algorithm: expectedAlgorithm,
                                                date: expectedDate,
@@ -230,7 +230,7 @@ final class CoreAwsS3ServiceClientTests: XCTestCase {
         
         let result = try client.signPolicy(bucket: bucket, key: key, acl: acl, contentType: contentType)
         
-        XCTAssertEqual(expectedPolicy, result.description)
+        XCTAssertEqual(expectedPolicy, result.policy)
         XCTAssertEqual(expectedSignature, result.signature)
         XCTAssertEqual(expectedAlgorithm, result.algorithm)
         XCTAssertEqual(expectedDate, result.date)

--- a/StitchCoreServicesAwsSes/Sources/StitchCoreServicesAwsSes/Internal/CoreAwsSesServiceClient.swift
+++ b/StitchCoreServicesAwsSes/Sources/StitchCoreServicesAwsSes/Internal/CoreAwsSesServiceClient.swift
@@ -2,8 +2,7 @@ import Foundation
 import MongoSwift
 import StitchCore
 
-open class CoreAwsSesServiceClient {
-    
+public final class CoreAwsSesServiceClient {
     private let service: CoreStitchServiceClient
     
     public init(withService service: CoreStitchServiceClient) {

--- a/StitchCoreServicesTwilio/Sources/StitchCoreServicesTwilio/CoreTwilioServiceClient.swift
+++ b/StitchCoreServicesTwilio/Sources/StitchCoreServicesTwilio/CoreTwilioServiceClient.swift
@@ -2,7 +2,7 @@ import Foundation
 import MongoSwift
 import StitchCore
 
-open class CoreTwilioServiceClient {
+public final class CoreTwilioServiceClient {
     
     private let service: CoreStitchServiceClient
     

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -4,6 +4,75 @@
 
 This project follows [Semantic Versioning 2.0](https://semver.org/). In general, every release is associated with a tag and a changelog. `master` serves as the mainline branch for the project and represent the latest state of development.
 
+### Adding a new module
+
+To add a new module the Stitch workspace, use this procedure.
+
+1. `mkdir <module name>`
+2. cd `<module_name>`
+3. `swift package init`
+4. `rm Tests/LinuxMain.swift Tests/StitchCoreServicesAwsS3Tests/XCTestManifests.swift`
+5. Add the dependency `.package(url: "../StitchCore", branch: "master"),`
+6. Add any other necessary dependencies
+7. Copy the `.xccconfig` file from `StitchCore` and rename it to `<module_name>.xcconfig` This will ensure that the necessary include paths and linker flags to compile with `libbson` and `libmongoc` are added when running `make`.
+8. Copy the `Makefile` from `StitchCore`, and change all instances of `StitchCore` to the name of the new module.
+9. Update the `Makefile` in the root directory to include the make tasks for the newly created module.
+10. Add the following the `.gitignore` for the entire project:
+    ```
+    <module name>/Packages/
+    <module name>/Package.pins
+    <module name>/Package.resolved
+    <module name>/.build/
+    <module name>/<module name>.xcodeproj/
+    ```
+11. Run `make` in the root directory
+12. Drag the generated XCode project into the `Stitch` workspace, being careful not to make it a subproject of any other project.
+13. In the Evergreen task for for `run_ios_tests`, add the following build commands:
+    ```
+    echo "!building <module-name>!"
+    xcodebuild -workspace Stitch.xcworkspace/ -scheme <module-name>-Package -configuration Debug -derivedDataPath build -destination "platform=iOS Simulator,name=iPhone 7,OS=11.2"
+    ```
+
+
+If creating an iOS-specific module to complement the module:
+1. Create a new "Cocoa Touch Framework" project in XCode.
+2. Give it the name `<module_name>-iOS`
+3. Ensure that "Include Unit Tests" is selected
+4. Ensure that you add it to the `Stitch` workspace and the `Stitch` group.
+5. In the "Build Phases" for the main target, add `StitchCore_iOS.framework` and the core module on top of which you are building as dependencies in "Link Binary with Libraries".
+6. In the "Build Phases" for the test target, add `StitchCoreTestUtils_iOS.framework` and `StitchCoreTestUtils.framework` as dependencies in "Link Binary with Libraries".
+8. In the "Build Settings" for both the main target and test target, add the following setting for "Header Search Paths,
+   ```
+   //:configuration = Debug
+    HEADER_SEARCH_PATHS = $(SRCROOT)/../Sources/libbson $(SRCROOT)/../Sources/libmongoc
+
+    //:configuration = Release
+    HEADER_SEARCH_PATHS = $(SRCROOT)/../Sources/libbson $(SRCROOT)/../Sources/libmongoc
+
+    //:completeSettings = some
+    HEADER_SEARCH_PATHS
+
+   ```
+   and the following setting for "Library Search Paths"
+   ```
+    //:configuration = Debug
+    LIBRARY_SEARCH_PATHS = $(SRCROOT)/../MobileSDKs/iphoneos/lib
+
+    //:configuration = Release
+    LIBRARY_SEARCH_PATHS = $(SRCROOT)/../MobileSDKs/iphoneos/lib
+
+    //:completeSettings = some
+    LIBRARY_SEARCH_PATHS
+
+   ```
+
+7. In the Evergreen task for `run_ios_tests`, add the following commands:
+    ```
+    echo "!testing <module-name>-iOS!"
+    xcodebuild test -workspace Stitch.xcworkspace/ -scheme <module-name>-iOS -configuration Debug -derivedDataPath build -destination "platform=iOS Simulator,name=iPhone 7,OS=11.2"
+    ```
+
+
 ### Publishing a New SDK version
 ```bash
 # update podspecs for affected modules in relation to semver as it applies
@@ -18,12 +87,12 @@ This project follows [Semantic Versioning 2.0](https://semver.org/). In general,
 git push upstream && git push upstream --tags
 VERSION=`cat StitchCore.podspec | grep "s.version" | head -1 | sed -E 's/[[:space:]]+s\.version.*=.*"(.*)"/\1/'`
 for spec in *.podspec ; do
-	name=`echo $spec | sed -E 's/(.*)\.podspec/\1/'`
-	if pod trunk info $name | grep "$VERSION" > /dev/null; then
-		continue
-	fi
-	echo pushing $name @ $VERSION to trunk
-	pod trunk push $spec
+    name=`echo $spec | sed -E 's/(.*)\.podspec/\1/'`
+    if pod trunk info $name | grep "$VERSION" > /dev/null; then
+        continue
+    fi
+    echo pushing $name @ $VERSION to trunk
+    pod trunk push $spec
 done
 
 # send an email detailing the changes to the https://groups.google.com/d/forum/mongodb-stitch-announce mailing list


### PR DESCRIPTION
Pretty much the same as SES, and also added some info to `contrib/README.md` that will help people add new modules until we have an automated script to do so.

This is slightly different from the Java implementation in that we expose additional overloads of all the putObject methods that allow specifying a timeout, since customizable timeouts on a per-request basis may be useful for people who are uploading large files via `putObject`. I will file a ticket for the same thing to be done on Java.