### PR TITLE
STITCH-1371 Implement HTTP service in Core and iOS

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -198,6 +198,8 @@ tasks:
             xcodebuild test -workspace Stitch.xcworkspace/ -scheme StitchCoreServicesAwsS3-iOS -configuration Debug -derivedDataPath build -destination "id=$SIM_UUID"
             echo "!testing StitchCoreServicesAwsSes-iOS!"
             xcodebuild test -workspace Stitch.xcworkspace/ -scheme StitchCoreServicesAwsSes-iOS -configuration Debug -derivedDataPath build -destination "id=$SIM_UUID"
+            echo "!testing StitchCoreServicesHttp-iOS!"
+            xcodebuild test -workspace Stitch.xcworkspace/ -scheme StitchCoreServicesHttp-iOS -configuration Debug -derivedDataPath build -destination "id=$SIM_UUID"
             echo "!testing StitchCoreServicesTwilio-iOS!"
             xcodebuild test -workspace Stitch.xcworkspace/ -scheme StitchCoreServicesTwilio-iOS -configuration Debug -derivedDataPath build -destination "id=$SIM_UUID"
 

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,12 @@ StitchCoreServicesAwsSes/Package.resolved
 StitchCoreServicesAwsSes/.build/
 StitchCoreServicesAwsSes/StitchCoreServicesAwsSes.xcodeproj/
 
+StitchCoreServicesHttp/Packages/
+StitchCoreServicesHttp/Package.pins
+StitchCoreServicesHttp/Package.resolved
+StitchCoreServicesHttp/.build/
+StitchCoreServicesHttp/StitchCoreServicesHttp.xcodeproj/
+
 StitchCoreServicesTwilio/Packages/
 StitchCoreServicesTwilio/Package.pins
 StitchCoreServicesTwilio/Package.resolved

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all:
 	$(MAKE) -C StitchCoreTestUtils all
 	$(MAKE) -C StitchCoreServicesAwsS3 all
 	$(MAKE) -C StitchCoreServicesAwsSes all
+	$(MAKE) -C StitchCoreServicesHttp all
 	$(MAKE) -C StitchCoreServicesTwilio all
 lint:
 	$(MAKE) -C MockUtils lint
@@ -13,6 +14,7 @@ lint:
 	$(MAKE) -C StitchCoreTestUtils lint
 	$(MAKE) -C StitchCoreServicesAwsS3 lint
 	$(MAKE) -C StitchCoreServicesAwsSes lint
+	$(MAKE) -C StitchCoreServicesHttp lint
 	$(MAKE) -C StitchCoreServicesTwilio lint
 git:
 	$(MAKE) -C MockUtils git
@@ -21,6 +23,7 @@ git:
 	$(MAKE) -C StitchCoreTestUtils git
 	$(MAKE) -C StitchCoreServicesAwsS3 git
 	$(MAKE) -C StitchCoreServicesAwsSes git
+	$(MAKE) -C StitchCoreServicesHttp git
 	$(MAKE) -C StitchCoreServicesTwilio git
 update:
 	$(MAKE) -C MockUtils update
@@ -29,6 +32,7 @@ update:
 	$(MAKE) -C StitchCoreTestUtils update
 	$(MAKE) -C StitchCoreServicesAwsS3 update
 	$(MAKE) -C StitchCoreServicesAwsSes update
+	$(MAKE) -C StitchCoreServicesHttp update
 	$(MAKE) -C StitchCoreServicesTwilio update
 test:
 	$(MAKE) -C MockUtils test
@@ -37,6 +41,7 @@ test:
 	$(MAKE) -C StitchCoreTestUtils test
 	$(MAKE) -C StitchCoreServicesAwsS3 test
 	$(MAKE) -C StitchCoreServicesAwsSes test
+	$(MAKE) -C StitchCoreServicesHttp test
 	$(MAKE) -C StitchCoreServicesTwilio test
 project:
 	$(MAKE) -C MockUtils project
@@ -45,4 +50,5 @@ project:
 	$(MAKE)	-C StitchCoreTestUtils project
 	$(MAKE) -C StitchCoreServicesAwsS3 project
 	$(MAKE) -C StitchCoreServicesAwsSes project
+	$(MAKE) -C StitchCoreServicesHttp project
 	$(MAKE) -C StitchCoreServicesTwilio project

--- a/Stitch.xcworkspace/contents.xcworkspacedata
+++ b/Stitch.xcworkspace/contents.xcworkspacedata
@@ -23,6 +23,9 @@
       location = "group:StitchCoreServicesHttp/StitchCoreServicesHttp.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:StitchCoreServicesTwilio/StitchCoreServicesTwilio.xcodeproj">
    </FileRef>
    <FileRef

--- a/Stitch.xcworkspace/contents.xcworkspacedata
+++ b/Stitch.xcworkspace/contents.xcworkspacedata
@@ -20,6 +20,9 @@
       location = "group:StitchCoreServicesAwsSes-iOS/StitchCoreServicesAwsSes-iOS.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:StitchCoreServicesHttp/StitchCoreServicesHttp.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:StitchCoreServicesTwilio/StitchCoreServicesTwilio.xcodeproj">
    </FileRef>
    <FileRef

--- a/StitchCoreAdminClient/Sources/StitchCoreAdminClient/Services/ServiceConfigs.swift
+++ b/StitchCoreAdminClient/Sources/StitchCoreAdminClient/Services/ServiceConfigs.swift
@@ -25,11 +25,7 @@ private struct ServiceConfigWrapper<SC: ServiceConfig>: Encodable {
     }
 }
 
-private struct HttpServiceConfig: ServiceConfig {
-    init() {
-        fatalError("HttpServiceConfig not implemented")
-    }
-}
+private struct HttpServiceConfig: ServiceConfig { }
 
 /// Configuration for an AWS S3 service
 private struct AwsS3ServiceConfig: ServiceConfig {

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS.xcodeproj/project.pbxproj
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS.xcodeproj/project.pbxproj
@@ -1,0 +1,522 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		118C33AE20C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 118C33A420C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.framework */; };
+		118C33B320C72B7B00D1DE80 /* StitchCoreServicesHttp_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118C33B220C72B7B00D1DE80 /* StitchCoreServicesHttp_iOSTests.swift */; };
+		118C33B520C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 118C33A720C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		118C33C020C72B9500D1DE80 /* StitchCore_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 118C33BF20C72B9500D1DE80 /* StitchCore_iOS.framework */; };
+		118C33C220C72B9500D1DE80 /* StitchCoreServicesHttp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 118C33C120C72B9500D1DE80 /* StitchCoreServicesHttp.framework */; };
+		118C33C420C72BA700D1DE80 /* StitchCoreTestUtils_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 118C33C320C72BA700D1DE80 /* StitchCoreTestUtils_iOS.framework */; };
+		118C33C620C72BA700D1DE80 /* StitchCoreTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 118C33C520C72BA700D1DE80 /* StitchCoreTestUtils.framework */; };
+		118C33C920C72DE300D1DE80 /* HttpServiceClientImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118C33C820C72DE300D1DE80 /* HttpServiceClientImpl.swift */; };
+		118C33CB20C72DF400D1DE80 /* HttpServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118C33CA20C72DF400D1DE80 /* HttpServiceClient.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		118C33AF20C72B7B00D1DE80 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 118C339B20C72B7B00D1DE80 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 118C33A320C72B7B00D1DE80;
+			remoteInfo = "StitchCoreServicesHttp-iOS";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		118C33A420C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StitchCoreServicesHttp_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		118C33A720C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StitchCoreServicesHttp_iOS.h; sourceTree = "<group>"; };
+		118C33A820C72B7B00D1DE80 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		118C33AD20C72B7B00D1DE80 /* StitchCoreServicesHttp-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "StitchCoreServicesHttp-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		118C33B220C72B7B00D1DE80 /* StitchCoreServicesHttp_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchCoreServicesHttp_iOSTests.swift; sourceTree = "<group>"; };
+		118C33B420C72B7B00D1DE80 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		118C33BF20C72B9500D1DE80 /* StitchCore_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCore_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		118C33C120C72B9500D1DE80 /* StitchCoreServicesHttp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreServicesHttp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		118C33C320C72BA700D1DE80 /* StitchCoreTestUtils_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreTestUtils_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		118C33C520C72BA700D1DE80 /* StitchCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		118C33C820C72DE300D1DE80 /* HttpServiceClientImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpServiceClientImpl.swift; sourceTree = "<group>"; };
+		118C33CA20C72DF400D1DE80 /* HttpServiceClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpServiceClient.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		118C33A020C72B7B00D1DE80 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				118C33C020C72B9500D1DE80 /* StitchCore_iOS.framework in Frameworks */,
+				118C33C220C72B9500D1DE80 /* StitchCoreServicesHttp.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		118C33AA20C72B7B00D1DE80 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				118C33C420C72BA700D1DE80 /* StitchCoreTestUtils_iOS.framework in Frameworks */,
+				118C33C620C72BA700D1DE80 /* StitchCoreTestUtils.framework in Frameworks */,
+				118C33AE20C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		118C339A20C72B7B00D1DE80 = {
+			isa = PBXGroup;
+			children = (
+				118C33A620C72B7B00D1DE80 /* StitchCoreServicesHttp-iOS */,
+				118C33B120C72B7B00D1DE80 /* StitchCoreServicesHttp-iOSTests */,
+				118C33A520C72B7B00D1DE80 /* Products */,
+				118C33BE20C72B9500D1DE80 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		118C33A520C72B7B00D1DE80 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				118C33A420C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.framework */,
+				118C33AD20C72B7B00D1DE80 /* StitchCoreServicesHttp-iOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		118C33A620C72B7B00D1DE80 /* StitchCoreServicesHttp-iOS */ = {
+			isa = PBXGroup;
+			children = (
+				118C33C720C72DD000D1DE80 /* Internal */,
+				118C33A720C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.h */,
+				118C33A820C72B7B00D1DE80 /* Info.plist */,
+				118C33CA20C72DF400D1DE80 /* HttpServiceClient.swift */,
+			);
+			path = "StitchCoreServicesHttp-iOS";
+			sourceTree = "<group>";
+		};
+		118C33B120C72B7B00D1DE80 /* StitchCoreServicesHttp-iOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				118C33B220C72B7B00D1DE80 /* StitchCoreServicesHttp_iOSTests.swift */,
+				118C33B420C72B7B00D1DE80 /* Info.plist */,
+			);
+			path = "StitchCoreServicesHttp-iOSTests";
+			sourceTree = "<group>";
+		};
+		118C33BE20C72B9500D1DE80 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				118C33C320C72BA700D1DE80 /* StitchCoreTestUtils_iOS.framework */,
+				118C33C520C72BA700D1DE80 /* StitchCoreTestUtils.framework */,
+				118C33BF20C72B9500D1DE80 /* StitchCore_iOS.framework */,
+				118C33C120C72B9500D1DE80 /* StitchCoreServicesHttp.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		118C33C720C72DD000D1DE80 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				118C33C820C72DE300D1DE80 /* HttpServiceClientImpl.swift */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		118C33A120C72B7B00D1DE80 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				118C33B520C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		118C33A320C72B7B00D1DE80 /* StitchCoreServicesHttp-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 118C33B820C72B7B00D1DE80 /* Build configuration list for PBXNativeTarget "StitchCoreServicesHttp-iOS" */;
+			buildPhases = (
+				118C339F20C72B7B00D1DE80 /* Sources */,
+				118C33A020C72B7B00D1DE80 /* Frameworks */,
+				118C33A120C72B7B00D1DE80 /* Headers */,
+				118C33A220C72B7B00D1DE80 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "StitchCoreServicesHttp-iOS";
+			productName = "StitchCoreServicesHttp-iOS";
+			productReference = 118C33A420C72B7B00D1DE80 /* StitchCoreServicesHttp_iOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		118C33AC20C72B7B00D1DE80 /* StitchCoreServicesHttp-iOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 118C33BB20C72B7B00D1DE80 /* Build configuration list for PBXNativeTarget "StitchCoreServicesHttp-iOSTests" */;
+			buildPhases = (
+				118C33A920C72B7B00D1DE80 /* Sources */,
+				118C33AA20C72B7B00D1DE80 /* Frameworks */,
+				118C33AB20C72B7B00D1DE80 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				118C33B020C72B7B00D1DE80 /* PBXTargetDependency */,
+			);
+			name = "StitchCoreServicesHttp-iOSTests";
+			productName = "StitchCoreServicesHttp-iOSTests";
+			productReference = 118C33AD20C72B7B00D1DE80 /* StitchCoreServicesHttp-iOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		118C339B20C72B7B00D1DE80 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0930;
+				LastUpgradeCheck = 0930;
+				ORGANIZATIONNAME = MongoDB;
+				TargetAttributes = {
+					118C33A320C72B7B00D1DE80 = {
+						CreatedOnToolsVersion = 9.3.1;
+						LastSwiftMigration = 0930;
+					};
+					118C33AC20C72B7B00D1DE80 = {
+						CreatedOnToolsVersion = 9.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 118C339E20C72B7B00D1DE80 /* Build configuration list for PBXProject "StitchCoreServicesHttp-iOS" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 118C339A20C72B7B00D1DE80;
+			productRefGroup = 118C33A520C72B7B00D1DE80 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				118C33A320C72B7B00D1DE80 /* StitchCoreServicesHttp-iOS */,
+				118C33AC20C72B7B00D1DE80 /* StitchCoreServicesHttp-iOSTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		118C33A220C72B7B00D1DE80 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		118C33AB20C72B7B00D1DE80 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		118C339F20C72B7B00D1DE80 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				118C33CB20C72DF400D1DE80 /* HttpServiceClient.swift in Sources */,
+				118C33C920C72DE300D1DE80 /* HttpServiceClientImpl.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		118C33A920C72B7B00D1DE80 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				118C33B320C72B7B00D1DE80 /* StitchCoreServicesHttp_iOSTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		118C33B020C72B7B00D1DE80 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 118C33A320C72B7B00D1DE80 /* StitchCoreServicesHttp-iOS */;
+			targetProxy = 118C33AF20C72B7B00D1DE80 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		118C33B620C72B7B00D1DE80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		118C33B720C72B7B00D1DE80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		118C33B920C72B7B00D1DE80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Sources/libbson",
+					"$(SRCROOT)/../Sources/libmongoc",
+				);
+				INFOPLIST_FILE = "StitchCoreServicesHttp-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../MobileSDKs/iphoneos/lib";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mongodb.StitchCoreServicesHttp-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		118C33BA20C72B7B00D1DE80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Sources/libbson",
+					"$(SRCROOT)/../Sources/libmongoc",
+				);
+				INFOPLIST_FILE = "StitchCoreServicesHttp-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../MobileSDKs/iphoneos/lib";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mongodb.StitchCoreServicesHttp-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		118C33BC20C72B7B00D1DE80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Sources/libbson",
+					"$(SRCROOT)/../Sources/libmongoc",
+				);
+				INFOPLIST_FILE = "StitchCoreServicesHttp-iOSTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../MobileSDKs/iphoneos/lib";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mongodb.StitchCoreServicesHttp-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		118C33BD20C72B7B00D1DE80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/../Sources/libbson",
+					"$(SRCROOT)/../Sources/libmongoc",
+				);
+				INFOPLIST_FILE = "StitchCoreServicesHttp-iOSTests/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../MobileSDKs/iphoneos/lib";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mongodb.StitchCoreServicesHttp-iOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		118C339E20C72B7B00D1DE80 /* Build configuration list for PBXProject "StitchCoreServicesHttp-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				118C33B620C72B7B00D1DE80 /* Debug */,
+				118C33B720C72B7B00D1DE80 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		118C33B820C72B7B00D1DE80 /* Build configuration list for PBXNativeTarget "StitchCoreServicesHttp-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				118C33B920C72B7B00D1DE80 /* Debug */,
+				118C33BA20C72B7B00D1DE80 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		118C33BB20C72B7B00D1DE80 /* Build configuration list for PBXNativeTarget "StitchCoreServicesHttp-iOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				118C33BC20C72B7B00D1DE80 /* Debug */,
+				118C33BD20C72B7B00D1DE80 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 118C339B20C72B7B00D1DE80 /* Project object */;
+}

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS.xcodeproj/xcshareddata/xcschemes/StitchCoreServicesHttp-iOS.xcscheme
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS.xcodeproj/xcshareddata/xcschemes/StitchCoreServicesHttp-iOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0930"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "118C33A320C72B7B00D1DE80"
+               BuildableName = "StitchCoreServicesHttp_iOS.framework"
+               BlueprintName = "StitchCoreServicesHttp-iOS"
+               ReferencedContainer = "container:StitchCoreServicesHttp-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "118C33AC20C72B7B00D1DE80"
+               BuildableName = "StitchCoreServicesHttp-iOSTests.xctest"
+               BlueprintName = "StitchCoreServicesHttp-iOSTests"
+               ReferencedContainer = "container:StitchCoreServicesHttp-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "118C33A320C72B7B00D1DE80"
+            BuildableName = "StitchCoreServicesHttp_iOS.framework"
+            BlueprintName = "StitchCoreServicesHttp-iOS"
+            ReferencedContainer = "container:StitchCoreServicesHttp-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "118C33A320C72B7B00D1DE80"
+            BuildableName = "StitchCoreServicesHttp_iOS.framework"
+            BlueprintName = "StitchCoreServicesHttp-iOS"
+            ReferencedContainer = "container:StitchCoreServicesHttp-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "118C33A320C72B7B00D1DE80"
+            BuildableName = "StitchCoreServicesHttp_iOS.framework"
+            BlueprintName = "StitchCoreServicesHttp-iOS"
+            ReferencedContainer = "container:StitchCoreServicesHttp-iOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/HttpServiceClient.swift
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/HttpServiceClient.swift
@@ -1,0 +1,45 @@
+import Foundation
+import StitchCore
+import StitchCoreServicesHttp
+import StitchCore_iOS
+
+private final class HttpNamedServiceClientFactory: NamedServiceClientFactory {
+    typealias ClientType = HttpServiceClient
+    
+    func client(withServiceClient serviceClient: StitchServiceClient,
+                withClientInfo clientInfo: StitchAppClientInfo) -> HttpServiceClient {
+        return HttpServiceClientImpl(
+            withClient: CoreHttpServiceClient.init(withService: serviceClient),
+            withDispatcher: OperationDispatcher(withDispatchQueue: DispatchQueue.global())
+        )
+    }
+}
+
+public protocol HttpServiceClient {
+    /**
+     * Executes the given `HttpRequest`.
+     *
+     * - parameters:
+     *     - request: The request to execute
+     *     - completionHandler: The completion handler to call when the request is complete or the operation fails.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     */
+    func execute(request: HttpRequest, _ completionHandler: @escaping (HttpResponse?, Error?) -> Void)
+    
+    /**
+     * Executes the given `HttpRequest`. A timeout can be specified if the operation is expected to
+     * take longer than the default timeout configured for the Stitch app client.
+     *
+     * - parameters:
+     *     - request: The request to execute
+     *     - completionHandler: The completion handler to call when the request is complete or the operation fails.
+     *                          This handler is executed on a non-main global `DispatchQueue`.
+     */
+    func execute(request: HttpRequest, timeout: TimeInterval, _ completionHandler: @escaping (HttpResponse?, Error?) -> Void)
+}
+
+public final class HttpService {
+    public static let sharedFactory = AnyNamedServiceClientFactory<HttpServiceClient>(
+        factory: HttpNamedServiceClientFactory()
+    )
+}

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/Info.plist
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/Internal/HttpServiceClientImpl.swift
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/Internal/HttpServiceClientImpl.swift
@@ -1,0 +1,28 @@
+import Foundation
+import StitchCore_iOS
+import StitchCoreServicesHttp
+
+public final class HttpServiceClientImpl: HttpServiceClient {
+    private let proxy: CoreHttpServiceClient
+    private let dispatcher: OperationDispatcher
+    
+    internal init(withClient client: CoreHttpServiceClient,
+                  withDispatcher dispatcher: OperationDispatcher) {
+        self.proxy = client
+        self.dispatcher = dispatcher
+    }
+    
+    public func execute(request: HttpRequest, _ completionHandler: @escaping (HttpResponse?, Error?) -> Void) {
+        self.dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.proxy.execute(request: request)
+        }
+    }
+    
+    public func execute(request: HttpRequest,
+                        timeout: TimeInterval,
+                        _ completionHandler: @escaping (HttpResponse?, Error?) -> Void) {
+        self.dispatcher.run(withCompletionHandler: completionHandler) {
+            return try self.proxy.execute(request: request, timeout: timeout)
+        }
+    }
+}

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp_iOS.h
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp_iOS.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+//! Project version number for StitchCoreServicesHttp_iOS.
+FOUNDATION_EXPORT double StitchCoreServicesHttp_iOSVersionNumber;
+
+//! Project version string for StitchCoreServicesHttp_iOS.
+FOUNDATION_EXPORT const unsigned char StitchCoreServicesHttp_iOSVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <StitchCoreServicesHttp_iOS/PublicHeader.h>
+
+

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp_iOS.h
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp_iOS.h
@@ -7,5 +7,3 @@ FOUNDATION_EXPORT double StitchCoreServicesHttp_iOSVersionNumber;
 FOUNDATION_EXPORT const unsigned char StitchCoreServicesHttp_iOSVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <StitchCoreServicesHttp_iOS/PublicHeader.h>
-
-

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOSTests/Info.plist
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOSTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOSTests/StitchCoreServicesHttp_iOSTests.swift
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOSTests/StitchCoreServicesHttp_iOSTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+
+import MongoSwift
+import StitchCore
+import StitchCoreAdminClient
+import StitchCoreTestUtils_iOS
+import StitchCoreServicesHttp
+@testable import StitchCoreServicesHttp_iOS
+
+class StitchCoreServicesHttp_iOSTests: BaseStitchIntTestCocoaTouch {
+    
+    func testExecute() throws {
+        let app = try self.createApp()
+        let _ = try self.addProvider(toApp: app.1, withConfig: ProviderConfigs.anon())
+        let svc = try self.addService(
+            toApp: app.1,
+            withType: "http",
+            withName: "http1",
+            withConfig: ServiceConfigs.http(name: "http1")
+        )
+        _ = try self.addRule(toService: svc.1,
+                             withConfig: RuleCreator.init(name: "rule",
+                                                          actions: RuleActionsCreator.http(
+                                                            get: true, post: false, put: false,
+                                                            delete: true, patch: false, head: false)))
+        
+        let client = try self.appClient(forApp: app.0)
+        
+        let exp0 = expectation(description: "should login")
+        client.auth.login(withCredential: AnonymousCredential()) { _,_  in
+            exp0.fulfill()
+        }
+        wait(for: [exp0], timeout: 5.0)
+        
+        let httpClient = client.serviceClient(forFactory: HttpService.sharedFactory, withName: "http1")
+        
+        // Specifying a request with a form AND body should fail.
+        var badUrl = "http://aol.com"
+        let method = HttpMethod.delete
+        let body = "hello world".data(using: .utf8)!
+        let cookies = ["bob": "barker"]
+        let form: [String: String] = [:]
+        let headers = ["myHeader": ["value1", "value2"]]
+        
+        var badRequest = try HttpRequestBuilder()
+            .with(url: badUrl)
+            .with(method: method)
+            .with(body: body)
+            .with(cookies: cookies)
+            .with(form: form)
+            .with(headers: headers)
+            .build()
+        
+        let exp1 = expectation(description: "should not make request")
+        httpClient.execute(request: badRequest) { (_, error) in
+            switch error as? StitchError {
+            case .serviceError(_, let withServiceErrorCode)?:
+                XCTAssertEqual(StitchServiceErrorCode.invalidParameter, withServiceErrorCode)
+            default:
+                XCTFail()
+            }
+            exp1.fulfill()
+        }
+        wait(for: [exp1], timeout: 5.0)
+        
+        // Executing a request against a bad domain should fail
+        badUrl = "http://127.0.0.1:234"
+        
+        badRequest = try HttpRequestBuilder()
+            .with(url: badUrl)
+            .with(method: method)
+            .with(body: body)
+            .with(cookies: cookies)
+            .with(headers: headers)
+            .build()
+        
+        let exp2 = expectation(description: "should not make request")
+        httpClient.execute(request: badRequest) { (_, error) in
+            switch error as? StitchError {
+            case .serviceError(_, let withServiceErrorCode)?:
+                XCTAssertEqual(StitchServiceErrorCode.httpError, withServiceErrorCode)
+            default:
+                XCTFail()
+            }
+            exp2.fulfill()
+        }
+        wait(for: [exp2], timeout: 5.0)
+        
+        // A correctly specific request should succeed
+        let goodRequest = try HttpRequestBuilder()
+            .with(url: "https://httpbin.org/delete")
+            .with(method: method)
+            .with(body: body)
+            .with(cookies: cookies)
+            .with(headers: headers)
+            .build()
+        
+        let exp3 = expectation(description: "request should be successfully completed")
+        var response: HttpResponse!
+        httpClient.execute(request: goodRequest) { (resp, _) in
+            XCTAssertNotNil(resp)
+            response = resp!
+            exp3.fulfill()
+        }
+        wait(for: [exp3], timeout: 5.0)
+        
+        XCTAssertEqual("200 OK", response!.status)
+        XCTAssertEqual(200, response!.statusCode)
+        XCTAssertTrue(300 <= response!.contentLength && response!.contentLength <= 400)
+        XCTAssertNotNil(response!.body)
+
+        let dataDoc = try Document.init(fromJSON: response!.body!)
+        
+        let dataString: String = try dataDoc.get("data")
+        XCTAssertEqual(String.init(data: body, encoding: .utf8)!, dataString)
+        
+        let headersDoc: Document = try dataDoc.get("headers")
+        XCTAssertEqual("value1,value2", try headersDoc.get("Myheader"))
+        XCTAssertEqual("bob=barker", try headersDoc.get("Cookie"))
+    }
+}

--- a/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOSTests/StitchCoreServicesHttp_iOSTests.swift
+++ b/StitchCoreServicesHttp-iOS/StitchCoreServicesHttp-iOSTests/StitchCoreServicesHttp_iOSTests.swift
@@ -8,7 +8,6 @@ import StitchCoreServicesHttp
 @testable import StitchCoreServicesHttp_iOS
 
 class StitchCoreServicesHttp_iOSTests: BaseStitchIntTestCocoaTouch {
-    
     func testExecute() throws {
         let app = try self.createApp()
         let _ = try self.addProvider(toApp: app.1, withConfig: ProviderConfigs.anon())

--- a/StitchCoreServicesHttp/.gitignore
+++ b/StitchCoreServicesHttp/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/StitchCoreServicesHttp/Makefile
+++ b/StitchCoreServicesHttp/Makefile
@@ -1,0 +1,18 @@
+all: git clean update project build
+git:
+	git init
+	git add .
+	git commit --allow-empty -m "init"
+lint:
+	swiftlint
+clean:
+	swift package clean
+build:
+	swift build -Xcc -I../MobileSDKs/include/libbson-1.0/ -Xcc -I../MobileSDKs/include/libmongoc-1.0
+update:
+	swift package update
+test:
+	# temporary until a fix is in for .brew dependency for libmongoc
+	xcodebuild test -workspace ../Stitch.xcworkspace/ -scheme StitchCoreServicesHttp-Package -configuration Debug -destination "platform=iOS Simulator,name=iPhone 7,OS=11.2"
+project:
+	swift package generate-xcodeproj --xcconfig-overrides StitchCoreServicesHttp.xcconfig

--- a/StitchCoreServicesHttp/Package.swift
+++ b/StitchCoreServicesHttp/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "StitchCoreServicesHttp",
+    products: [
+        .library(
+            name: "StitchCoreServicesHttp",
+            targets: ["StitchCoreServicesHttp"]),
+    ],
+    dependencies: [
+        .package(url: "../StitchCore", .branch("master"))
+    ],
+    targets: [
+        .target(
+            name: "StitchCoreServicesHttp",
+            dependencies: ["StitchCore"]),
+        .testTarget(
+            name: "StitchCoreServicesHttpTests",
+            dependencies: ["StitchCoreServicesHttp", "StitchCoreMocks"]),
+    ]
+)

--- a/StitchCoreServicesHttp/README.md
+++ b/StitchCoreServicesHttp/README.md
@@ -1,0 +1,3 @@
+# StitchCoreServicesHttp
+
+A description of this package.

--- a/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpCookie.swift
+++ b/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpCookie.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/**
+ * Represents a RFC 6265 cookie.
+ */
+public struct HttpCookie {
+    public enum CodingKeys: String, CodingKey {
+        case value, path, domain, expires, maxAge, secure, httpOnly
+    }
+    
+    /**
+     * The name of the cookie.
+     */
+    public let name: String
+    
+    /**
+     * The value of the cookie.
+     */
+    public let value: String
+    
+    /**
+     * The path within the domain to which this cookie belongs.
+     */
+    public let path: String?
+    
+    /**
+     * The domain to which this cookie belongs.
+     */
+    public let domain: String?
+    
+    /**
+     * When the cookie expires
+     */
+    public let expires: String?
+    
+    /**
+     * How long the cookie can live for.
+     */
+    public let maxAge: String?
+    
+    /**
+     * Whether or not this cookie can only be sent to HTTPS servers.
+     */
+    public let secure: Bool?
+    
+    /**
+     * Whether or not this cookie can only be read by a server.
+     */
+    public let httpOnly: Bool?
+}

--- a/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpMethod.swift
+++ b/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpMethod.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/**
+ * The series of methods accepted by the HTTP service.
+ */
+public enum HttpMethod: String {
+    case get, post, put, delete, head, patch
+}

--- a/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpRequest.swift
+++ b/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpRequest.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+/**
+ * An error that the HttpRequest builder can throw if it is missing certain configuration properties.
+ */
+public enum HttpRequestBuilderError: Error {
+    case missingMethod
+    case missingUrl
+}
+
+/**
+ * An HttpRequest encapsulates the details of an HTTP request over the HTTP service.
+ */
+public struct HttpRequest {
+    /**
+     * The URL that the request will be performed against.
+     */
+    public let url: String
+    
+    /**
+     * The HTTP method of the request.
+     */
+    public let method: HttpMethod
+    
+    /**
+     * The URL that will be used to capture cookies for authentication before the actual request is executed.
+     */
+    public let authUrl: String?
+    
+    /**
+     * The headers that will be included in the request.
+     */
+    public let headers: [String: [String]]?
+    
+    /**
+     * The cookies that will be included in the request.
+     */
+    public let cookies: [String: String]?
+    
+    /**
+     * The body that will be included in the request.
+     */
+    public let body: Data?
+    
+    /**
+     * Whether or not the included body should be encoded as extended JSON when sent to the url in this request.
+     */
+    public let encodeBodyAsJson: Bool?
+    
+    /**
+     * The form that will be included in the request.
+     */
+    public let form: [String: String]?
+    
+    /**
+     * Whether or not Stitch should follow redirects while executing the request. Defaults to false.
+     */
+    public let followRedirects: Bool?
+}
+
+public class HttpRequestBuilder {
+    internal var url: String?
+    internal var method: HttpMethod?
+    internal var authUrl: String?
+    internal var headers: [String: [String]]?
+    internal var cookies: [String: String]?
+    internal var body: Data?
+    internal var encodeBodyAsJson: Bool?
+    internal var form: [String: String]?
+    internal var followRedirects: Bool?
+    
+    /**
+     * Sets the URL that the request will be performed against.
+     */
+    @discardableResult
+    public func with(url: String) -> Self {
+        self.url = url
+        return self
+    }
+    
+    /**
+     * Sets the HTTP method of the request.
+     */
+    @discardableResult
+    public func with(method: HttpMethod) -> Self {
+        self.method = method
+        return self
+    }
+    
+    /**
+     * Sets the URL that will be used to capture cookies for authentication before the actual request is executed.
+     */
+    @discardableResult
+    public func with(authUrl: String) -> Self {
+        self.authUrl = authUrl
+        return self
+    }
+    
+    /**
+     * Sets the headers that will be included in the request.
+     */
+    @discardableResult
+    public func with(headers: [String: [String]]) -> Self {
+        self.headers = headers
+        return self
+    }
+    
+    /**
+     * Sets the cookies that will be included in the request.
+     */
+    @discardableResult
+    public func with(cookies: [String: String]) -> Self {
+        self.cookies = cookies
+        return self
+    }
+    
+    /**
+     * Sets the body that will be included in the request.
+     */
+    @discardableResult
+    public func with(body: Data?) -> Self {
+        self.body = body
+        return self
+    }
+    
+    /**
+     * Sets whether or not the included body should be encoded as extended JSON when sent to the url in this request.
+     * Defaults to false if not set.
+     */
+    @discardableResult
+    public func with(encodeBodyAsJson: Bool) -> Self {
+        self.encodeBodyAsJson = encodeBodyAsJson
+        return self
+    }
+    
+    /**
+     * Sets the form that will be included in the request.
+     */
+    @discardableResult
+    public func with(form: [String: String]) -> Self {
+        self.form = form
+        return self
+    }
+    
+    /**
+     * Sets whether or not Stitch should follow redirects while executing the request. Defaults to false if not set.
+     */
+    @discardableResult
+    public func with(followRedirects: Bool) -> Self {
+        self.followRedirects = followRedirects
+        return self
+    }
+    
+    /**
+     * Builds, validates, and returns the `HttpRequest`.
+     */
+    public func build() throws -> HttpRequest {
+        guard let url = url, url != "" else {
+            throw HttpRequestBuilderError.missingUrl
+        }
+        
+        guard let method = method else {
+            throw HttpRequestBuilderError.missingMethod
+        }
+        
+        return HttpRequest.init(
+            url: url,
+            method: method,
+            authUrl: authUrl,
+            headers: headers,
+            cookies: cookies,
+            body: body,
+            encodeBodyAsJson: encodeBodyAsJson,
+            form: form,
+            followRedirects: followRedirects
+        )
+    }
+}
+

--- a/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpRequest.swift
+++ b/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpRequest.swift
@@ -69,6 +69,8 @@ public class HttpRequestBuilder {
     internal var form: [String: String]?
     internal var followRedirects: Bool?
     
+    public init() { }
+    
     /**
      * Sets the URL that the request will be performed against.
      */

--- a/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpResponse.swift
+++ b/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpResponse.swift
@@ -78,37 +78,12 @@ public struct HttpResponse: Decodable {
                     throw MongoError.typeError(message: "expected string value for cookie value in HTTP service response")
                 }
                 
-                let keys = document.keys
-                
-                var path: String?
-                if keys.contains(HttpCookie.CodingKeys.path.rawValue) {
-                    path = try? document.get(HttpCookie.CodingKeys.path.rawValue)
-                }
-                
-                var domain: String?
-                if keys.contains(HttpCookie.CodingKeys.domain.rawValue) {
-                    domain = try? document.get(HttpCookie.CodingKeys.domain.rawValue)
-                }
-                
-                var expires: String?
-                if keys.contains(HttpCookie.CodingKeys.expires.rawValue) {
-                    expires = try? document.get(HttpCookie.CodingKeys.expires.rawValue)
-                }
-                
-                var maxAge: String?
-                if keys.contains(HttpCookie.CodingKeys.maxAge.rawValue) {
-                    maxAge = try? document.get(HttpCookie.CodingKeys.maxAge.rawValue)
-                }
-                
-                var secure: Bool?
-                if keys.contains(HttpCookie.CodingKeys.secure.rawValue) {
-                    secure = try? document.get(HttpCookie.CodingKeys.secure.rawValue)
-                }
-                
-                var httpOnly: Bool?
-                if keys.contains(HttpCookie.CodingKeys.httpOnly.rawValue) {
-                    httpOnly = try? document.get(HttpCookie.CodingKeys.httpOnly.rawValue)
-                }
+                let path = document[HttpCookie.CodingKeys.path.rawValue] as? String
+                let domain = document[HttpCookie.CodingKeys.domain.rawValue] as? String
+                let expires = document[HttpCookie.CodingKeys.expires.rawValue] as? String
+                let maxAge = document[HttpCookie.CodingKeys.maxAge.rawValue] as? String
+                let secure = document[HttpCookie.CodingKeys.secure.rawValue] as? Bool
+                let httpOnly = document[HttpCookie.CodingKeys.httpOnly.rawValue] as? Bool
                 
                 cookies[key] = HttpCookie.init(
                     name: key,

--- a/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpResponse.swift
+++ b/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/HttpResponse.swift
@@ -1,0 +1,130 @@
+import Foundation
+import MongoSwift
+
+/**
+ * The response to an HTTP request over the HTTP service.
+ */
+public struct HttpResponse: Decodable {
+    public enum CodingKeys: String, CodingKey {
+        case status, statusCode, contentLength, headers, cookies, body
+    }
+    
+    /**
+     * The human readable status of the response.
+     */
+    public let status: String
+    
+    /**
+     * The status code of the response.
+     */
+    public let statusCode: Int
+    
+    /**
+     * The content length of the response.
+     */
+    public let contentLength: Int64
+    
+    /**
+     * The response headers.
+     */
+    public let headers: [String: [String]]?
+    
+    /**
+     * The response cookies.
+     */
+    public let cookies: [String: HttpCookie]?
+    
+    /**
+     * The response body.
+     */
+    public let body: Data?
+    
+    internal init(status: String,
+                  statusCode: Int,
+                  contentLength: Int64,
+                  headers: [String: [String]]?,
+                  cookies: [String: HttpCookie],
+                  body: Data?) {
+        self.status = status
+        self.statusCode = statusCode
+        self.contentLength = contentLength
+        self.headers = headers
+        self.cookies = cookies
+        self.body = body
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.status = try container.decode(String.self, forKey: .status)
+        self.statusCode = try container.decode(Int.self, forKey: .statusCode)
+        self.contentLength = try container.decode(Int64.self, forKey: .contentLength)
+        self.headers = try container.decodeIfPresent([String: [String]].self, forKey: .headers)
+        
+        if let bsonBinaryBody = try container.decodeIfPresent(Binary.self, forKey: .body) {
+            self.body = bsonBinaryBody.data
+        } else {
+            self.body = nil
+        }
+        
+        if let decodedCookies = try container.decodeIfPresent(Document.self, forKey: .cookies) {
+            var cookies: [String: HttpCookie] = [:]
+            try decodedCookies.forEach { (key, bsonValue) in
+                guard let document = bsonValue as? Document else {
+                    throw MongoError.typeError(message: "unexpected cookie type in HTTP service response")
+                }
+                
+                guard let value: String = try? document.get("value") else {
+                    throw MongoError.typeError(message: "expected string value for cookie value in HTTP service response")
+                }
+                
+                let keys = document.keys
+                
+                var path: String?
+                if keys.contains(HttpCookie.CodingKeys.path.rawValue) {
+                    path = try? document.get(HttpCookie.CodingKeys.path.rawValue)
+                }
+                
+                var domain: String?
+                if keys.contains(HttpCookie.CodingKeys.domain.rawValue) {
+                    domain = try? document.get(HttpCookie.CodingKeys.domain.rawValue)
+                }
+                
+                var expires: String?
+                if keys.contains(HttpCookie.CodingKeys.expires.rawValue) {
+                    expires = try? document.get(HttpCookie.CodingKeys.expires.rawValue)
+                }
+                
+                var maxAge: String?
+                if keys.contains(HttpCookie.CodingKeys.maxAge.rawValue) {
+                    maxAge = try? document.get(HttpCookie.CodingKeys.maxAge.rawValue)
+                }
+                
+                var secure: Bool?
+                if keys.contains(HttpCookie.CodingKeys.secure.rawValue) {
+                    secure = try? document.get(HttpCookie.CodingKeys.secure.rawValue)
+                }
+                
+                var httpOnly: Bool?
+                if keys.contains(HttpCookie.CodingKeys.httpOnly.rawValue) {
+                    httpOnly = try? document.get(HttpCookie.CodingKeys.httpOnly.rawValue)
+                }
+                
+                cookies[key] = HttpCookie.init(
+                    name: key,
+                    value: value,
+                    path: path,
+                    domain: domain,
+                    expires: expires,
+                    maxAge: maxAge,
+                    secure: secure,
+                    httpOnly: httpOnly
+                )
+            }
+            
+            self.cookies = cookies
+        } else {
+            self.cookies = nil
+        }
+    }
+}

--- a/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/Internal/CoreHttpServiceClient.swift
+++ b/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/Internal/CoreHttpServiceClient.swift
@@ -26,12 +26,12 @@ public final class CoreHttpServiceClient {
                 args["cookies"] = try BsonEncoder().encode(cookies)
             }
             
-            if let encodeBodyAsJson = request.encodeBodyAsJson {
-                args["encodeBodyAsJSON"] = encodeBodyAsJson
-            }
-            
             if let body = request.body {
                 args["body"] = Binary.init(data: body, subtype: .binary)
+            }
+            
+            if let encodeBodyAsJson = request.encodeBodyAsJson {
+                args["encodeBodyAsJSON"] = encodeBodyAsJson
             }
             
             if let form = request.form {

--- a/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/Internal/CoreHttpServiceClient.swift
+++ b/StitchCoreServicesHttp/Sources/StitchCoreServicesHttp/Internal/CoreHttpServiceClient.swift
@@ -1,0 +1,58 @@
+import Foundation
+import MongoSwift
+import StitchCore
+
+public final class CoreHttpServiceClient {
+    private let service: CoreStitchServiceClient
+    
+    public init(withService service: CoreStitchServiceClient) {
+        self.service = service
+    }
+    
+    public func execute(request: HttpRequest,
+                        timeout: TimeInterval? = nil) throws -> HttpResponse {
+        var args: Document = [ "url": request.url ]
+        
+        do {
+            if let authUrl = request.authUrl {
+                args["authUrl"] = authUrl
+            }
+            
+            if let headers = request.headers {
+                args["headers"] = try BsonEncoder().encode(headers)
+            }
+            
+            if let cookies = request.cookies {
+                args["cookies"] = try BsonEncoder().encode(cookies)
+            }
+            
+            if let encodeBodyAsJson = request.encodeBodyAsJson {
+                args["encodeBodyAsJSON"] = encodeBodyAsJson
+            }
+            
+            if let body = request.body {
+                args["body"] = Binary.init(data: body, subtype: .binary)
+            }
+            
+            if let form = request.form {
+                args["form"] = try BsonEncoder().encode(form)
+            }
+            
+            if let followRedirects = request.followRedirects {
+                args["followRedirects"] = followRedirects
+            }
+        } catch let error {
+            if let stitchError = error as? StitchError {
+                throw stitchError
+            }
+            
+            throw StitchError.requestError(withError: error, withRequestErrorCode: .encodingError)
+        }
+        
+        return try service.callFunctionInternal(
+            withName: request.method.rawValue,
+            withArgs: [args],
+            withRequestTimeout: timeout
+        )
+    }
+}

--- a/StitchCoreServicesHttp/StitchCoreServicesHttp.xcconfig
+++ b/StitchCoreServicesHttp/StitchCoreServicesHttp.xcconfig
@@ -1,0 +1,21 @@
+//
+// StitchCoreServicesHttp.xcconfig
+//
+
+OTHER_LDFLAGS[sdk=iphoneos*] = -rpath $(SRCROOT)/../MobileSDKs/iphoneos/lib
+OTHER_LDFLAGS[sdk=iphonesimulator*] = -rpath $(SRCROOT)/../MobileSDKs/iphoneos/lib
+OTHER_LDFLAGS[sdk=appletvos*] = -rpath $(SRCROOT)/../MobileSDKs/appletvos/lib
+OTHER_LDFLAGS[sdk=appletvsimulator*] = -rpath $(SRCROOT)/../MobileSDKs/appletvos/lib
+LIBRARY_SEARCH_PATHS[sdk=iphoneos*]        = $(SRCROOT)/../MobileSDKs/iphoneos/lib
+LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*] = $(SRCROOT)/../MobileSDKs/iphoneos/lib
+LIBRARY_SEARCH_PATHS[sdk=appletvos*]       = $(SRCROOT)/../MobileSDKs/appletvos/lib
+LIBRARY_SEARCH_PATHS[sdk=appletvsimulator*] = $(SRCROOT)/../MobileSDKs/appletvos/lib
+
+SWIFT_INCLUDE_PATHS = $(SRCROOT)/../MobileSDKs/include $(SRCROOT)/../MobileSDKs/include/libbson-1.0 $(SRCROOT)/../MobileSDKs/include/libmongoc-1.0
+
+ENABLE_BITCODE = NO
+
+IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos*]=8.0
+IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator*]=8.0
+IPHONEOS_DEPLOYMENT_TARGET[sdk=appletvos*]=8.0
+IPHONEOS_DEPLOYMENT_TARGET[sdk=appletvsimulator*]=8.0

--- a/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/HttpRequestTests.swift
+++ b/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/HttpRequestTests.swift
@@ -61,8 +61,11 @@ final class HttpRequestTests: XCTestCase {
         XCTAssertEqual(false, fullRequest.encodeBodyAsJson!)
         XCTAssertEqual(true, fullRequest.followRedirects!)
         XCTAssertEqual(expectedForm, fullRequest.form!)
-        XCTAssertEqual(expectedHeaders, fullRequest.headers!)
+        
+        // Workaround since `XCTAssertEqual(expectedHeaders, fullRequest.headers!)` does not compile on Evergreen
+        expectedHeaders.forEach { (key, value) in
+            XCTAssertTrue(fullRequest.headers!.keys.contains(key))
+            XCTAssertEqual(value, fullRequest.headers![key])
+        }
     }
-    
 }
-

--- a/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/HttpRequestTests.swift
+++ b/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/HttpRequestTests.swift
@@ -54,13 +54,14 @@ final class HttpRequestTests: XCTestCase {
         
         XCTAssertEqual(expectedUrl, fullRequest.url)
         XCTAssertEqual(expectedMethod, fullRequest.method)
-        XCTAssertEqual(expectedAuthUrl, fullRequest.authUrl)
-        XCTAssertEqual(expectedBody, fullRequest.body)
-        XCTAssertEqual(expectedCookies, fullRequest.cookies)
-        XCTAssertEqual(false, fullRequest.encodeBodyAsJson)
-        XCTAssertEqual(true, fullRequest.followRedirects)
-        XCTAssertEqual(expectedForm, fullRequest.form)
-        XCTAssertEqual(expectedHeaders, fullRequest.headers)
+        
+        XCTAssertEqual(expectedAuthUrl, fullRequest.authUrl!)
+        XCTAssertEqual(expectedBody, fullRequest.body!)
+        XCTAssertEqual(expectedCookies, fullRequest.cookies!)
+        XCTAssertEqual(false, fullRequest.encodeBodyAsJson!)
+        XCTAssertEqual(true, fullRequest.followRedirects!)
+        XCTAssertEqual(expectedForm, fullRequest.form!)
+        XCTAssertEqual(expectedHeaders, fullRequest.headers!)
     }
     
 }

--- a/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/HttpRequestTests.swift
+++ b/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/HttpRequestTests.swift
@@ -65,7 +65,7 @@ final class HttpRequestTests: XCTestCase {
         // Workaround since `XCTAssertEqual(expectedHeaders, fullRequest.headers!)` does not compile on Evergreen
         expectedHeaders.forEach { (key, value) in
             XCTAssertTrue(fullRequest.headers!.keys.contains(key))
-            XCTAssertEqual(value, fullRequest.headers![key])
+            XCTAssertEqual(value, fullRequest.headers![key]!)
         }
     }
 }

--- a/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/HttpRequestTests.swift
+++ b/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/HttpRequestTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import StitchCoreServicesHttp
+
+final class HttpRequestTests: XCTestCase {
+    
+    func testBuilder() throws {
+        XCTAssertThrowsError(try HttpRequestBuilder().build()) { error in
+            XCTAssertTrue(error is HttpRequestBuilderError)
+        }
+        
+        XCTAssertThrowsError(try HttpRequestBuilder().with(url: "http://aol.com").build()) { error in
+            XCTAssertTrue(error is HttpRequestBuilderError)
+        }
+        
+        XCTAssertThrowsError(try HttpRequestBuilder().with(method: .delete).build()) { error in
+            XCTAssertTrue(error is HttpRequestBuilderError)
+        }
+        
+        // Minimum satisfied
+        let expectedUrl = "http://aol.com"
+        let expectedMethod = HttpMethod.delete
+        
+        let request = try HttpRequestBuilder().with(url: expectedUrl).with(method: expectedMethod).build()
+        
+        XCTAssertEqual(expectedUrl, request.url)
+        XCTAssertEqual(expectedMethod, request.method)
+        
+        XCTAssertNil(request.authUrl)
+        XCTAssertNil(request.body)
+        XCTAssertNil(request.cookies)
+        XCTAssertNil(request.encodeBodyAsJson)
+        XCTAssertNil(request.followRedirects)
+        XCTAssertNil(request.form)
+        XCTAssertNil(request.headers)
+        
+        // Full params
+        let expectedAuthUrl = "https://username@password:woo.com";
+        let expectedBody = "hello world!".data(using: .utf8)!
+        let expectedCookies: [String: String] = ["some":"cookie"]
+        let expectedForm: [String: String] = ["some": "form"]
+        let expectedHeaders: [String: [String]] = ["some": ["head", "ers"]]
+        
+        let fullRequest = try HttpRequestBuilder()
+            .with(url: expectedUrl)
+            .with(authUrl: expectedAuthUrl)
+            .with(method: expectedMethod)
+            .with(body: expectedBody)
+            .with(cookies: expectedCookies)
+            .with(encodeBodyAsJson: false)
+            .with(followRedirects: true)
+            .with(form: expectedForm)
+            .with(headers: expectedHeaders)
+            .build()
+        
+        XCTAssertEqual(expectedUrl, fullRequest.url)
+        XCTAssertEqual(expectedMethod, fullRequest.method)
+        XCTAssertEqual(expectedAuthUrl, fullRequest.authUrl)
+        XCTAssertEqual(expectedBody, fullRequest.body)
+        XCTAssertEqual(expectedCookies, fullRequest.cookies)
+        XCTAssertEqual(false, fullRequest.encodeBodyAsJson)
+        XCTAssertEqual(true, fullRequest.followRedirects)
+        XCTAssertEqual(expectedForm, fullRequest.form)
+        XCTAssertEqual(expectedHeaders, fullRequest.headers)
+    }
+    
+}
+

--- a/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/Internal/CoreHttpServiceClientTests.swift
+++ b/StitchCoreServicesHttp/Tests/StitchCoreServicesHttpTests/Internal/CoreHttpServiceClientTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import MongoSwift
+import StitchCore
+import StitchCoreMocks
+@testable import StitchCoreServicesHttp
+
+final class CoreHttpServiceClientTests: XCTestCase {
+    func testExecute() throws {
+        let service = MockCoreStitchService()
+        let client = CoreHttpServiceClient.init(withService: service)
+        
+        let expectedUrl = "http://aol.com"
+        let expectedMethod = HttpMethod.delete
+        let expectedAuthUrl = "https://username@password:woo.com";
+        let expectedBody = "hello world!".data(using: .utf8)!
+        let expectedCookies: [String: String] = ["some":"cookie"]
+        let expectedForm: [String: String] = ["some": "form"]
+        let expectedHeaders: [String: [String]] = ["some": ["head", "ers"]]
+        
+        let request = try HttpRequestBuilder()
+            .with(url: expectedUrl)
+            .with(authUrl: expectedAuthUrl)
+            .with(method: expectedMethod)
+            .with(body: expectedBody)
+            .with(cookies: expectedCookies)
+            .with(encodeBodyAsJson: false)
+            .with(followRedirects: true)
+            .with(form: expectedForm)
+            .with(headers: expectedHeaders)
+            .build()
+        
+        let response = HttpResponse.init(
+            status: "OK",
+            statusCode: 200,
+            contentLength: 304,
+            headers: expectedHeaders,
+            cookies: [:],
+            body: "response body".data(using: .utf8)
+        )
+        
+        service.callFunctionInternalWithDecodingMock.doReturn(
+            result: response, forArg1: .any, forArg2: .any, forArg3: .any
+        )
+        
+        _ = try client.execute(request: request)
+        
+        let (funcNameArg, funcArgsArg, _) = service.callFunctionInternalWithDecodingMock.capturedInvocations.last!
+        
+        XCTAssertEqual("delete", funcNameArg)
+        XCTAssertEqual(1, funcArgsArg.count)
+        
+        let expectedArgs: Document = [
+            "url": expectedUrl,
+            "authUrl": expectedAuthUrl,
+            "headers": try BsonEncoder().encode(expectedHeaders),
+            "cookies": try BsonEncoder().encode(expectedCookies),
+            "body": Binary.init(data: expectedBody, subtype: .binary),
+            "encodeBodyAsJSON": false,
+            "form": try BsonEncoder().encode(expectedForm),
+            "followRedirects": true
+        ]
+        
+        XCTAssertEqual(expectedArgs, funcArgsArg[0] as? Document)
+        
+        // should pass along errors
+        service.callFunctionInternalWithDecodingMock.doThrow(
+            error: StitchError.serviceError(withMessage: "", withServiceErrorCode: .unknown),
+            forArg1: .any,
+            forArg2: .any,
+            forArg3: .any
+        )
+        
+        do {
+            _ = try client.execute(request: request)
+            XCTFail("function did not fail where expected")
+        } catch {
+            // do nothing
+        }
+    }
+}

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -43,7 +43,7 @@ If creating an iOS-specific module to complement the module:
 6. In the "Build Phases" for the test target, add `StitchCoreTestUtils_iOS.framework` and `StitchCoreTestUtils.framework` as dependencies in "Link Binary with Libraries".
 7. In the "Build Settings" for both the main target and test target, add the following setting for "Header Search Paths,
    ```
-   //:configuration = Debug
+    //:configuration = Debug
     HEADER_SEARCH_PATHS = $(SRCROOT)/../Sources/libbson $(SRCROOT)/../Sources/libmongoc
 
     //:configuration = Release
@@ -71,7 +71,7 @@ If creating an iOS-specific module to complement the module:
 9. In the Evergreen task for `run_ios_tests`, add the following commands:
     ```
     echo "!testing <module-name>-iOS!"
-    xcodebuild test -workspace Stitch.xcworkspace/ -scheme <module-name>-iOS -configuration Debug -derivedDataPath build -destination "platform=iOS Simulator,name=iPhone 7,OS=11.2"
+    xcodebuild test -workspace Stitch.xcworkspace/ -scheme <module-name>-iOS -configuration Debug -derivedDataPath build -destination "id=$SIM_UUID"
     ```
 10. In "Product" -> "Scheme" -> "Manage Schemes", scroll to the newly created module `<module_name>-iOS`, and select the "Shared" checkbox.
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -11,8 +11,8 @@ To add a new module the Stitch workspace, use this procedure.
 1. `mkdir <module name>`
 2. cd `<module_name>`
 3. `swift package init`
-4. `rm Tests/LinuxMain.swift Tests/StitchCoreServicesAwsS3Tests/XCTestManifests.swift`
-5. Add the dependency `.package(url: "../StitchCore", branch: "master"),`
+4. `rm Tests/LinuxMain.swift Tests/<module_name>Tests/XCTestManifests.swift`
+5. Add the dependency `.package(url: "../StitchCore", .branch("master"))`
 6. Add any other necessary dependencies
 7. Copy the `.xccconfig` file from `StitchCore` and rename it to `<module_name>.xcconfig` This will ensure that the necessary include paths and linker flags to compile with `libbson` and `libmongoc` are added when running `make`.
 8. Copy the `Makefile` from `StitchCore`, and change all instances of `StitchCore` to the name of the new module.


### PR DESCRIPTION
almost no drivebys this time. `run_ios_tests` is still broken until we get them to reboot the box, but everything passes for me locally.