### PR TITLE
STITCH-2159 Split locking for authing and auth state

### DIFF
--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Internal/CoreStitchAuth+StitchAuthRequestClient.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Internal/CoreStitchAuth+StitchAuthRequestClient.swift
@@ -43,8 +43,9 @@ extension CoreStitchAuth {
      * (depending on the type of request) to the request's `"Authorization"` header.
      */
     private func prepareAuthRequest(_ stitchReq: StitchAuthRequest) throws -> StitchRequest {
-        objc_sync_enter(self)
-        defer { objc_sync_exit(self) }
+        objc_sync_enter(authStateLock)
+        defer { objc_sync_exit(authStateLock) }
+        
         guard self.isLoggedIn,
             let refreshToken = self.authStateHolder.refreshToken,
             let accessToken = self.authStateHolder.accessToken else {

--- a/Core/StitchCoreSDK/Tests/StitchCoreSDKTests/Auth/Internal/CoreStitchAuthUnitTests.swift
+++ b/Core/StitchCoreSDK/Tests/StitchCoreSDKTests/Auth/Internal/CoreStitchAuthUnitTests.swift
@@ -438,7 +438,7 @@ class CoreStitchAuthUnitTests: StitchXCTestCase {
             result: Response(statusCode: 200, headers: baseJSONHeaders, body: docRaw.data(using: .utf8)),
             forArg: .any
         )
-        
+
         let documentResult: Document = try auth.doAuthenticatedRequest(reqBuilder.build())
         XCTAssertEqual(expectedObjectId, documentResult["_id"] as! ObjectId)
         XCTAssertEqual(42, documentResult["intValue"] as! Int)

--- a/Core/StitchCoreSDK/Tests/StitchCoreSDKTests/Auth/Internal/CoreStitchAuthUnitTests.swift
+++ b/Core/StitchCoreSDK/Tests/StitchCoreSDKTests/Auth/Internal/CoreStitchAuthUnitTests.swift
@@ -438,10 +438,10 @@ class CoreStitchAuthUnitTests: StitchXCTestCase {
             result: Response(statusCode: 200, headers: baseJSONHeaders, body: docRaw.data(using: .utf8)),
             forArg: .any
         )
-
+        
         let documentResult: Document = try auth.doAuthenticatedRequest(reqBuilder.build())
-        XCTAssertEqual(expectedObjectId, try documentResult.get("_id"))
-        XCTAssertEqual(42, try documentResult.get("intValue"))
+        XCTAssertEqual(expectedObjectId, documentResult["_id"] as! ObjectId)
+        XCTAssertEqual(42, documentResult["intValue"] as! Int)
 
         let customObjResult: CustomType = try auth.doAuthenticatedRequest(reqBuilder.build())
         XCTAssertEqual(expectedObjectId, customObjResult.id)

--- a/Darwin/Services/StitchHTTPService/StitchHTTPServiceTests/HTTPServiceClientIntTests.swift
+++ b/Darwin/Services/StitchHTTPService/StitchHTTPServiceTests/HTTPServiceClientIntTests.swift
@@ -133,12 +133,12 @@ class HTTPServiceClientIntTests: BaseStitchIntTestCocoaTouch {
             
             let dataDoc = try Document.init(fromJSON: response!.body!)
             
-            let dataString: String = try dataDoc.get("data")
+            let dataString: String = dataDoc["data"] as! String
             XCTAssertEqual(String.init(data: body, encoding: .utf8)!, dataString)
             
-            let headersDoc: Document = try dataDoc.get("headers")
-            XCTAssertEqual("value1,value2", try headersDoc.get("Myheader"))
-            XCTAssertEqual("bob=barker", try headersDoc.get("Cookie"))
+            let headersDoc: Document = dataDoc["headers"] as! Document
+            XCTAssertEqual("value1,value2", headersDoc["Myheader"] as! String)
+            XCTAssertEqual("bob=barker", headersDoc["Cookie"] as! String)
         }
     }
 }


### PR DESCRIPTION
Instead of `objc_sync_enter`-ing on `self`, we now do it on two separate objects to mimic the logic of the Android SDK.