### PR TITLE
STITCH-2212 Swift SDK: Create a skeleton for sync operations and the data synchronizer

### DIFF
--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ChangeEventListener.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ChangeEventListener.swift
@@ -24,7 +24,7 @@ internal final class AnyChangeEventListener: ChangeEventListener {
                 changeEventListener.onEvent(documentId: documentId,
                                             event: try ChangeEvent<U.DocumentT>.transform(changeEvent: event))
             } catch {
-                errorListener?.on(error: error, for: documentId, in: event.ns)
+                errorListener?.on(error: error, forDocumentId: documentId, in: event.ns)
             }
         }
     }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ChangeEventListener.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ChangeEventListener.swift
@@ -18,13 +18,13 @@ public protocol ChangeEventListener {
 internal final class AnyChangeEventListener: ChangeEventListener {
     private let _onEvent: (BSONValue, ChangeEvent<Document>) -> Void
 
-    init<U: ChangeEventListener>(_ changeEventListener: U, errorListener: ErrorListener?) {
+    init<U: ChangeEventListener>(_ changeEventListener: U, errorListener: FatalErrorListener?) {
         self._onEvent = { documentId, event in
             do {
                 changeEventListener.onEvent(documentId: documentId,
                                             event: try ChangeEvent<U.DocumentT>.transform(changeEvent: event))
             } catch {
-                errorListener?.on(error: error, forDocumentId: documentId)
+                errorListener?.on(error: error, for: documentId, in: event.ns)
             }
         }
     }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreDocumentSynchronizationConfig.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreDocumentSynchronizationConfig.swift
@@ -134,7 +134,7 @@ internal struct CoreDocumentSynchronization: Hashable {
                 let count = try docsColl.count(filter)
                 return count == 1
             } catch {
-                errorListener?.on(error: error, for: documentId.value, in: namespace)
+                errorListener?.on(error: error, forDocumentId: documentId.value, in: namespace)
                 return self.config.isStale
             }
         }
@@ -146,7 +146,7 @@ internal struct CoreDocumentSynchronization: Hashable {
                     filter: docConfigFilter(forNamespace: namespace, withDocumentId: documentId),
                     update: ["$set": [Config.CodingKeys.isStale.rawValue: value] as Document])
             } catch {
-                errorListener?.on(error: error, for: documentId.value, in: namespace)
+                errorListener?.on(error: error, forDocumentId: documentId.value, in: namespace)
             }
             self.config.isStale = value
         }
@@ -169,7 +169,7 @@ internal struct CoreDocumentSynchronization: Hashable {
                     update: [ "$set": [ Config.CodingKeys.isPaused.rawValue : value ] as Document
                     ])
             } catch {
-                errorListener?.on(error: error, for: documentId.value, in: namespace)
+                errorListener?.on(error: error, forDocumentId: documentId.value, in: namespace)
             }
             config.isPaused = value
         }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreSync.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreSync.swift
@@ -1,0 +1,230 @@
+import Foundation
+import MongoSwift
+
+open class CoreSync<DocumentT: Codable> {
+    private let namespace: MongoNamespace
+    private let dataSynchronizer: DataSynchronizer
+
+    public init(namespace: MongoNamespace,
+                dataSynchronizer: DataSynchronizer) {
+        self.namespace = namespace
+        self.dataSynchronizer = dataSynchronizer
+    }
+
+    /**
+      Set the conflict resolver and and change event listener on this collection.
+      - parameter conflictHandler: the conflict resolver to invoke when a conflict happens between local
+                             and remote events.
+      - parameter changeEventListener: the event listener to invoke when a change event happens for the
+                              document.
+      - parameter errorListener: the error listener to invoke when an irrecoverable error occurs
+     */
+    func configure<CH: ConflictHandler, CEL: ChangeEventListener>(
+        conflictHandler: CH,
+        changeEventListener: CEL,
+        errorListener: ErrorListener) where CH.DocumentT == DocumentT, CEL.DocumentT == DocumentT {
+        dataSynchronizer.configure(namespace: namespace,
+                                   conflictHandler: conflictHandler,
+                                   changeEventListener: changeEventListener,
+                                   errorListener: errorListener)
+    }
+
+    /**
+      Requests that the given document _ids be synchronized.
+      - parameter ids: the document _ids to synchronize.
+     */
+    func sync(ids: BSONValue...) {
+        self.dataSynchronizer.sync(ids: ids, in: namespace)
+    }
+
+    /**
+      Stops synchronizing the given document _ids. Any uncommitted writes will be lost.
+
+      - parameter ids the _ids of the documents to desynchronize.
+     */
+    func desync(ids: BSONValue...) {
+        self.dataSynchronizer.desync(ids: ids, in: namespace)
+    }
+
+    /**
+      Returns the set of synchronized document ids in a namespace.
+
+      - returns: the set of synchronized document ids in a namespace.
+     */
+    var syncedIds: Set<HashableBSONValue> {
+        return self.dataSynchronizer.syncedIds(in: namespace)
+    }
+
+    /**
+      Return the set of synchronized document _ids in a namespace
+      that have been paused due to an irrecoverable error.
+
+      - returns: the set of paused document _ids in a namespace
+     */
+    var pausedIds: Set<HashableBSONValue> {
+        return self.dataSynchronizer.pausedIds(in: namespace)
+    }
+
+    /**
+      A document that is paused no longer has remote updates applied to it.
+      Any local updates to this document cause it to be resumed. An example of pausing a document
+      is when a conflict is being resolved for that document and the handler throws an exception.
+
+      - parameter documentId: the id of the document to resume syncing
+      - returns: true if successfully resumed, false if the document
+              could not be found or there was an error resuming
+     */
+    func resumeSync(forDocumentId documentId: BSONValue) -> Bool {
+        return self.dataSynchronizer.resumeSync(for: documentId,
+                                                in: namespace)
+    }
+
+    /**
+      Counts the number of documents in the collection that have been synchronized with the remote.
+
+      - returns: the number of documents in the collection
+     */
+    func count() {
+        return self.dataSynchronizer.count(in: namespace)
+    }
+
+    /**
+      Counts the number of documents in the collection that have been synchronized with the remote
+      according to the given options.
+
+      - parameter filter:  the query filter
+      - parameter options: the options describing the count
+      - returns: the number of documents in the collection
+     */
+    func count(filter: Document, options: CountOptions?) {
+        return self.dataSynchronizer.count(filter: filter,
+                                           options: options,
+                                           in: namespace)
+    }
+
+    /**
+      Finds all documents in the collection that have been synchronized with the remote.
+
+      - returns: the find iterable interface
+     */
+    func find() -> MongoCursor<DocumentT> {
+        return self.dataSynchronizer.find(in: namespace)
+    }
+
+    /**
+      Finds all documents in the collection that have been synchronized with the remote.
+
+      - parameter filter: the query filter for this find op
+      - parameter options: the options for this findo p
+      - returns: the find iterable interface
+     */
+    func find(filter: Document, options: FindOptions?) -> MongoCursor<DocumentT> {
+        return self.dataSynchronizer.find(filter: filter,
+                                          options: options,
+                                          in: namespace)
+    }
+
+    /**
+      Aggregates documents that have been synchronized with the remote
+      according to the specified aggregation pipeline.
+
+      - parameter pipeline: the aggregation pipeline
+      - parameter options: the options for this aggregate op
+      - returns: an iterable containing the result of the aggregation operation
+     */
+    func aggregate(pipeline: [Document],
+                   options: AggregateOptions?) -> MongoCursor<Document> {
+        return self.dataSynchronizer.aggregate(pipeline: pipeline,
+                                               options: options,
+                                               in: namespace)
+    }
+
+
+
+    /**
+      Inserts the provided document. If the document is missing an identifier, the client should
+      generate one. Syncs the newly inserted document against the remote.
+
+      - parameter document: the document to insert
+      - returns: the result of the insert one operation
+     */
+    func insertOne(document: DocumentT) -> InsertOneResult? {
+        return self.dataSynchronizer.insertOne(document: document,
+                                               in: namespace)
+    }
+
+    /**
+      Inserts one or more documents. Syncs the newly inserted documents against the remote.
+
+      - parameter documents: the documents to insert
+      - returns: the result of the insert many operation
+     */
+    func insertMany(documents: DocumentT...) -> InsertManyResult? {
+        return self.dataSynchronizer.insertMany(documents: documents,
+                                                in: namespace)
+    }
+
+    /**
+      Removes at most one document from the collection that has been synchronized with the remote
+      that matches the given filter.  If no documents match, the collection is not
+      modified.
+
+      - parameter filter: the query filter to apply the the delete operation
+      - returns: the result of the remove one operation
+     */
+    func deleteOne(filter: Document) -> DeleteResult? {
+        return self.dataSynchronizer.deleteOne(filter: filter,
+                                               in: namespace)
+    }
+
+    /**
+      Removes all documents from the collection that have been synchronized with the remote
+      that match the given query filter.  If no documents match, the collection is not modified.
+
+      - parameter filter: the query filter to apply the the delete operation
+      - returns: the result of the remove many operation
+     */
+    func deleteMany(filter: Document) -> DeleteResult? {
+        return self.dataSynchronizer.deleteMany(filter: filter,
+                                                in: namespace)
+    }
+
+    /**
+      Update a single document in the collection that have been synchronized with the remote
+      according to the specified arguments. If the update results in an upsert,
+      the newly upserted document will automatically become synchronized.
+
+      - parameter filter: a document describing the query filter, which may not be null.
+      - parameter update: a document describing the update, which may not be null. The update to
+                    apply must include only update operators.
+      - returns: the result of the update one operation
+     */
+    func updateOne(filter: Document,
+                   update: Document,
+                   options: UpdateOptions?) -> UpdateResult? {
+        return self.dataSynchronizer.updateOne(filter: filter,
+                                               update: update,
+                                               options: options,
+                                               in: namespace)
+    }
+
+    /**
+      Update all documents in the collection that have been synchronized with the remote
+      according to the specified arguments. If the update results in an upsert,
+      the newly upserted document will automatically become synchronized.
+
+      - parameter filter: a document describing the query filter, which may not be null.
+      - parameter update: a document describing the update, which may not be null. The update to
+                          apply must include only update operators.
+      - parameter updateOptions: the options to apply to the update operation
+      - returns: the result of the update many operation
+     */
+    func updateMany(filter: Document,
+                    update: Document,
+                    options: UpdateOptions?) -> UpdateResult? {
+        return self.dataSynchronizer.updateMany(filter: filter,
+                                                update: update,
+                                                options: options,
+                                                in: namespace)
+    }
+}

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreSync.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreSync.swift
@@ -52,7 +52,7 @@ open class CoreSync<DocumentT: Codable> {
 
     /**
      Returns the set of synchronized document ids in a namespace.
-
+     TODO Remove custom HashableBSONValue after: https://jira.mongodb.org/browse/SWIFT-255
      - returns: the set of synchronized document ids in a namespace.
      */
     var syncedIds: Set<HashableBSONValue> {

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/DataSynchronizer.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/DataSynchronizer.swift
@@ -1,0 +1,515 @@
+import Foundation
+import MongoSwift
+import MongoMobile
+import StitchCoreSDK
+import os
+
+public class DataSynchronizer: NetworkStateListener, ErrorListener {
+    fileprivate static let shortSleepSeconds: UInt32 = 1
+    fileprivate static let longSleepSeconds: UInt32 = 5
+
+    /// The unique instance key for this DataSynchronizer
+    private let instanceKey: String
+    /// The associated service client
+    private let service: CoreStitchServiceClient
+    /// The associated embedded client
+    private let localClient: MongoClient
+    /// The associated remote client
+    private let remoteClient: CoreRemoteMongoClient
+    /// Network monitor that receives to network state
+    private let networkMonitor: NetworkMonitor
+    /// Auth monitor that receives auth state
+    private let authMonitor: AuthMonitor
+    /// Database to manage our configurations
+    private let configDb: MongoDatabase
+    /// The collection to store the configuration for this instance in
+    private let instancesColl: MongoCollection<InstanceSynchronization.Config>
+    /// The configuration for this sync instance
+    private var syncConfig: InstanceSynchronization
+
+    /// Whether or not the DataSynchronizer has been configured
+    private(set) var isConfigured = true
+    /// Whether or not the sync thread is enabled
+    private(set) var isSyncThreadEnabled = true
+
+    /// RW lock for the synchronizer
+    private let syncLock = ReadWriteLock()
+    /// RW lock for the listeners
+    private let listenersLock = ReadWriteLock()
+
+    private lazy var eventDispatchQueue = DispatchQueue.init(
+        label: "eventEmission-\(self.instanceKey)",
+        qos: .default,
+        attributes: .concurrent,
+        autoreleaseFrequency: .inherit)
+    private lazy var syncDispatchQueue = DispatchQueue.init(
+        label: "synchronizer-\(self.instanceKey)",
+        qos: .background,
+        autoreleaseFrequency: .never)
+    private let log: Log
+    private var syncWorkItem: DispatchWorkItem? = nil
+    private var errorListener: ErrorListener?
+    private var logicalT: Int = 0
+
+    var isRunning: Bool {
+        syncLock.readLock()
+        defer { syncLock.unlock() }
+        return syncWorkItem != nil && syncWorkItem?.isCancelled == false
+    }
+    
+    public init(instanceKey: String,
+                service: CoreStitchServiceClient,
+                localClient: MongoClient,
+                remoteClient: CoreRemoteMongoClient,
+                networkMonitor: NetworkMonitor,
+                authMonitor: AuthMonitor) throws {
+        self.instanceKey = instanceKey
+        self.service = service
+        self.localClient = localClient
+        self.remoteClient = remoteClient
+        self.networkMonitor = networkMonitor
+        self.authMonitor = authMonitor
+
+        self.configDb = try localClient.db("sync_config" + instanceKey)
+
+        self.instancesColl = try configDb.collection("instances",
+                                                     withType: InstanceSynchronization.Config.self)
+        self.log = Log.init(tag: "dataSynchronizer-\(instanceKey)")
+
+        if try instancesColl.count() == 0 {
+            self.syncConfig = try InstanceSynchronization(configDb: configDb,
+                                                          errorListener: nil)
+            try instancesColl.insertOne(self.syncConfig.config)
+        } else {
+            if try instancesColl.find().next() == nil {
+                throw StitchError.serviceError(withMessage: "expected to find instance configuration",
+                                               withServiceErrorCode: .unknown)
+            }
+            self.syncConfig = try InstanceSynchronization(configDb: configDb,
+                                                          errorListener: nil)
+        }
+
+        self.syncConfig.errorListener = self
+        self.networkMonitor.add(networkStateListener: self)
+    }
+
+    public func on(error: Error, forDocumentId documentId: BSONValue?) {
+
+    }
+
+    public func onNetworkStateChanged() {
+        if (!self.networkMonitor.isConnected()) {
+            self.stop()
+        } else {
+            self.start()
+        }
+    }
+
+    public func configure<CH: ConflictHandler, CEL: ChangeEventListener>(namespace: MongoNamespace,
+                                                                         conflictHandler: CH,
+                                                                         changeEventListener: CEL,
+                                                                         errorListener: ErrorListener) {
+        self.errorListener = errorListener
+
+        guard var nsConfig = self.syncConfig[namespace] else {
+            return
+        }
+
+        nsConfig.configure(conflictHandler: conflictHandler,
+                           changeEventListener: changeEventListener)
+
+        syncLock.writeLock()
+        defer { syncLock.unlock() }
+
+        if (!self.isConfigured) {
+            self.isConfigured = true
+            syncLock.unlock()
+            self.triggerListening(to: nsConfig.config.namespace)
+        } else {
+            syncLock.unlock()
+        }
+
+        if syncWorkItem == nil {
+            self.start()
+        }
+    }
+
+    /**
+     Reloads the synchronization config. This wipes all in-memory synchronization settings.
+     */
+    public func reloadConfig() throws {
+        syncLock.writeLock()
+        defer { syncLock.unlock() }
+
+        // TODO STITCH-2217 Stop listeners
+        if try instancesColl.find().next() == nil {
+            throw StitchError.serviceError(withMessage: "expected to find instance configuration",
+                                           withServiceErrorCode: .unknown)
+        }
+
+        self.syncConfig = try InstanceSynchronization(configDb: configDb, errorListener: self)
+        self.isConfigured = false
+        self.stop()
+    }
+
+    func doSyncPass() -> Bool {
+        // TODO Sync Logic
+        return true
+    }
+
+    /**
+     Starts data synchronization in a background thread.
+     */
+    public func start() {
+        syncLock.writeLock()
+        defer { syncLock.unlock() }
+        if (!self.isConfigured) {
+            return
+        }
+
+        // restart changestream listeners
+        if isSyncThreadEnabled {
+            self.syncWorkItem = DispatchWorkItem { [weak self] in
+                repeat {
+                    guard let dataSync = self else {
+                        return
+                    }
+
+                    var successful = false
+                    successful = dataSync.doSyncPass()
+
+                    if (successful) {
+                        sleep(DataSynchronizer.shortSleepSeconds)
+                    } else {
+                        sleep(DataSynchronizer.longSleepSeconds)
+                    }
+                } while self?.syncWorkItem?.isCancelled == false 
+            }
+
+            syncDispatchQueue.async(execute: self.syncWorkItem!)
+        }
+    }
+
+    /**
+     * Stops the background data synchronization thread.
+     */
+    public func stop() {
+        syncLock.writeLock()
+        defer { syncLock.unlock() }
+
+        guard let syncWorkItem = syncWorkItem else {
+            return
+        }
+        syncWorkItem.cancel()
+
+        let join = DispatchSemaphore.init(value: 0)
+        syncWorkItem.notify(queue: syncDispatchQueue) {
+            join.signal()
+        }
+        join.wait()
+        self.syncWorkItem = nil
+    }
+
+    /**
+     Requests that the given document _ids be synchronized.
+     - parameter ids: the document _ids to synchronize.
+     - parameter namespace: the namespace these documents belong to
+     */
+    func sync(ids: [BSONValue], in namespace: MongoNamespace) {
+        ids.forEach { id in
+            guard var nsConfig = syncConfig[namespace] else {
+                return
+            }
+
+            nsConfig.sync(id: id)
+        }
+
+        self.triggerListening(to: namespace)
+    }
+
+    /**
+     Stops synchronizing the given document _ids. Any uncommitted writes will be lost.
+
+     - parameter ids the _ids of the documents to desynchronize.
+     */
+    func desync(ids: [BSONValue], in namespace: MongoNamespace) {
+        ids.forEach { id in
+            guard var namespace = syncConfig[namespace] else {
+                return
+            }
+
+            namespace[id] = nil
+        }
+
+        self.triggerListening(to: namespace)
+    }
+
+    /**
+     Returns the set of synchronized document ids in a namespace.
+
+     - returns: the set of synchronized document ids in a namespace.
+     */
+    func syncedIds(in namespace: MongoNamespace) -> Set<HashableBSONValue> {
+        guard let nsConfig = syncConfig[namespace] else {
+            return Set()
+        }
+
+        let v = nsConfig.map { $0.documentId }
+        print(v)
+        return Set(nsConfig.map({HashableBSONValue($0.documentId)}))
+    }
+
+    /**
+     Return the set of synchronized document _ids in a namespace
+     that have been paused due to an irrecoverable error.
+
+     - returns: the set of paused document _ids in a namespace
+     */
+    func pausedIds(in namespace: MongoNamespace) -> Set<HashableBSONValue> {
+        guard let nsConfig = syncConfig[namespace] else {
+            return Set()
+        }
+
+        return Set(nsConfig.compactMap { docConfig in
+            guard docConfig.isPaused else {
+                return nil
+            }
+            return HashableBSONValue(docConfig.documentId)
+        })
+    }
+
+    /**
+     A document that is paused no longer has remote updates applied to it.
+     Any local updates to this document cause it to be resumed. An example of pausing a document
+     is when a conflict is being resolved for that document and the handler throws an exception.
+
+     - parameter documentId: the id of the document to resume syncing
+     - returns: true if successfully resumed, false if the document
+     could not be found or there was an error resuming
+     */
+    func resumeSync(for documentId: BSONValue,
+                    in namespace: MongoNamespace) -> Bool {
+        guard var nsConfig = syncConfig[namespace],
+            var docConfig = nsConfig[documentId] else {
+                return false
+        }
+
+        docConfig.isPaused = false
+        return !docConfig.isPaused
+    }
+
+    /**
+     Counts the number of documents in the collection that have been synchronized with the remote.
+
+     - parameter namespace: the namespace to conduct this op
+     - returns: the number of documents in the collection
+     */
+    func count(in namespace: MongoNamespace) {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Counts the number of documents in the collection that have been synchronized with the remote
+     according to the given options.
+
+     - parameter filter:  the query filter
+     - parameter options: the options describing the count
+     - parameter namespace: the namespace to conduct this op
+     - returns: the number of documents in the collection
+     */
+    func count(filter: Document,
+               options: CountOptions?,
+               in namespace: MongoNamespace) {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Finds all documents in the collection that have been synchronized with the remote.
+
+     - parameter namespace: the namespace to conduct this op
+     - returns: the find iterable interface
+     */
+    func find<DocumentT: Codable>(in namespace: MongoNamespace) -> MongoCursor<DocumentT> {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Finds all documents in the collection that have been synchronized with the remote.
+
+     - parameter filter: the query filter for this find op
+     - parameter options: the options for this find op
+     - parameter namespace: the namespace to conduct this op
+     - returns: the find iterable interface
+     */
+    func find<DocumentT: Codable>(filter: Document,
+                                  options: FindOptions?,
+                                  in namespace: MongoNamespace) -> MongoCursor<DocumentT> {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Aggregates documents that have been synchronized with the remote
+     according to the specified aggregation pipeline.
+
+     - parameter pipeline: the aggregation pipeline
+     - parameter options: the options for this aggregate op
+     - parameter namespace: the namespace to conduct this op
+     - returns: an iterable containing the result of the aggregation operation
+     */
+    func aggregate(pipeline: [Document],
+                   options: AggregateOptions?,
+                   in namespace: MongoNamespace) -> MongoCursor<Document> {
+        fatalError("\(#function) not implemented")
+    }
+
+
+
+    /**
+     Inserts the provided document. If the document is missing an identifier, the client should
+     generate one. Syncs the newly inserted document against the remote.
+
+     - parameter document: the document to insert
+     - parameter namespace: the namespace to conduct this op
+     - returns: the result of the insert one operation
+     */
+    func insertOne<DocumentT: Codable>(document: DocumentT,
+                                       in namespace: MongoNamespace) -> InsertOneResult? {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Inserts one or more documents. Syncs the newly inserted documents against the remote.
+
+     - parameter documents: the documents to insert
+     - parameter namespace: the namespace to conduct this op
+     - returns: the result of the insert many operation
+     */
+    func insertMany<DocumentT: Codable>(documents: DocumentT...,
+        in namespace: MongoNamespace) -> InsertManyResult? {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Removes at most one document from the collection that has been synchronized with the remote
+     that matches the given filter.  If no documents match, the collection is not
+     modified.
+
+     - parameter filter: the query filter to apply the the delete operation
+     - parameter namespace: the namespace to conduct this op
+     - returns: the result of the remove one operation
+     */
+    func deleteOne(filter: Document,
+                   in namespace: MongoNamespace) -> DeleteResult? {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Removes all documents from the collection that have been synchronized with the remote
+     that match the given query filter.  If no documents match, the collection is not modified.
+
+     - parameter filter: the query filter to apply the the delete operation
+     - parameter namespace: the namespace to conduct this op
+     - returns: the result of the remove many operation
+     */
+    func deleteMany(filter: Document,
+                    in namespace: MongoNamespace) -> DeleteResult? {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Update a single document in the collection that have been synchronized with the remote
+     according to the specified arguments. If the update results in an upsert,
+     the newly upserted document will automatically become synchronized.
+
+     - parameter filter: a document describing the query filter, which may not be null.
+     - parameter update: a document describing the update, which may not be null. The update to
+     apply must include only update operators.
+     - parameter namespace: the namespace to conduct this op
+     - returns: the result of the update one operation
+     */
+    func updateOne(filter: Document,
+                   update: Document,
+                   options: UpdateOptions?,
+                   in namespace: MongoNamespace) -> UpdateResult? {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Update all documents in the collection that have been synchronized with the remote
+     according to the specified arguments. If the update results in an upsert,
+     the newly upserted document will automatically become synchronized.
+
+     - parameter filter: a document describing the query filter, which may not be null.
+     - parameter update: a document describing the update, which may not be null. The update to
+     apply must include only update operators.
+     - parameter updateOptions: the options to apply to the update operation
+     - parameter namespace: the namespace to conduct this op
+     - returns: the result of the update many operation
+     */
+    func updateMany(filter: Document,
+                    update: Document,
+                    options: UpdateOptions?,
+                    in namespace: MongoNamespace) -> UpdateResult? {
+        fatalError("\(#function) not implemented")
+    }
+
+    /**
+     Emits a change event for the given document id.
+
+     - parameter documentId: the document that has a change event for it.
+     - parameter event:      the change event.
+     */
+    private func emitEvent(documentId: BSONValue, event: ChangeEvent<Document>) {
+        listenersLock.readLock()
+        defer { listenersLock.unlock() }
+
+        let nsConfig = syncConfig[event.ns]
+
+        eventDispatchQueue.async {
+            nsConfig?.changeEventListener?.onEvent(documentId: documentId,
+                                                   event: event)
+        }
+    }
+
+    /**
+     Emits an error for the given document id. This should be used
+     for irrecoverable errors. Pauses the doc config.
+     - parameter docConfig: document configuration the error occured on
+     - parameter error: the error that occured
+     */
+    private func emitError(docConfig: inout CoreDocumentSynchronization,
+                           error: Error) {
+        guard let errorListener = self.errorListener else {
+            return
+        }
+
+        let documentId = docConfig.documentId.value
+        self.eventDispatchQueue.async {
+            errorListener.on(error: error, forDocumentId: documentId)
+        }
+
+        docConfig.isPaused = true
+        log.e(error.localizedDescription)
+        log.e("Setting document to frozen: \(docConfig.documentId.value)")
+    }
+
+    private func triggerListening(to namespace: MongoNamespace) {
+        syncLock.writeLock()
+        defer { syncLock.unlock() }
+        do {
+            guard let nsConfig = self.syncConfig[namespace] else {
+                return
+            }
+
+            guard nsConfig.count > 0,
+                nsConfig.isConfigured else {
+                    // TODO STITCH-2217: removeNamespace
+                    return
+            }
+
+            // TODO STITCH-2217: addNamespace, stop, start
+        } catch {
+            log.e("t='\(logicalT)': triggerListeningToNamespace ns=\(namespace) exception: \(error)")
+        }
+    }
+}

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/DataSynchronizer.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/DataSynchronizer.swift
@@ -2,7 +2,6 @@ import Foundation
 import MongoSwift
 import MongoMobile
 import StitchCoreSDK
-import os
 
 /**
  DataSynchronizer handles the bidirectional synchronization of documents between a local MongoDB
@@ -482,7 +481,7 @@ public class DataSynchronizer: NetworkStateListener, FatalErrorListener {
 
     /// Potentially pass along useful error information to the user.
     /// This should only be used for low level errors.
-    func on(error: Error, for documentId: BSONValue?, in namespace: MongoNamespace?) {
+    func on(error: Error, forDocumentId documentId: BSONValue?, in namespace: MongoNamespace?) {
         guard let errorListener = self.errorListener else {
             return
         }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ErrorListener.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ErrorListener.swift
@@ -24,5 +24,5 @@ internal protocol FatalErrorListener: class {
      - parameter documentId: the _id of the document related to the error.
      - parameter namespace: the namespace the error may have occured in
      */
-    func on(error: Error, for documentId: BSONValue?, in namespace: MongoNamespace?)
+    func on(error: Error, forDocumentId documentId: BSONValue?, in namespace: MongoNamespace?)
 }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ErrorListener.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ErrorListener.swift
@@ -12,3 +12,17 @@ public protocol ErrorListener: class {
      */
     func on(error: Error, forDocumentId documentId: BSONValue?)
 }
+
+/**
+ FatalErrorListener receives low level errors unrelated to the sync process.
+*/
+internal protocol FatalErrorListener: class {
+    /**
+     Called when a fatal error occurs.
+
+     - parameter error: the error.
+     - parameter documentId: the _id of the document related to the error.
+     - parameter namespace: the namespace the error may have occured in
+     */
+    func on(error: Error, for documentId: BSONValue?, in namespace: MongoNamespace?)
+}

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ErrorListener.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ErrorListener.swift
@@ -3,7 +3,7 @@ import MongoSwift
 /**
  ErrorListener receives non-network related errors that occur.
  */
-protocol ErrorListener: class {
+public protocol ErrorListener: class {
     /**
      Called when an error happens for the given document id.
 

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/InstanceSynchronizationConfig.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/InstanceSynchronizationConfig.swift
@@ -111,7 +111,7 @@ internal struct InstanceSynchronization: Sequence {
                 config.namespaces[namespace] = newConfig.config
                 return newConfig
             } catch {
-                errorListener?.on(error: error, for: nil, in: namespace)
+                errorListener?.on(error: error, forDocumentId: nil, in: namespace)
             }
 
             return nil

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/InstanceSynchronizationConfig.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/InstanceSynchronizationConfig.swift
@@ -12,7 +12,7 @@ import MongoSwift
  */
 internal struct InstanceSynchronization: Sequence {
     /// The actual configuration to be persisted for this instance.
-    struct Config {
+    struct Config: Codable {
         fileprivate var namespaces: [MongoNamespace: NamespaceSynchronization.Config]
     }
 
@@ -53,13 +53,13 @@ internal struct InstanceSynchronization: Sequence {
     private let namespacesColl: MongoCollection<NamespaceSynchronization.Config>
     private let docsColl: MongoCollection<CoreDocumentSynchronization.Config>
     private let instanceLock = ReadWriteLock()
-    private weak var errorListener: ErrorListener?
+    weak var errorListener: ErrorListener?
 
     /// The configuration for this instance.
     private(set) var config: Config
 
     init(configDb: MongoDatabase,
-         errorListener: ErrorListener) throws {
+         errorListener: ErrorListener?) throws {
         self.namespacesColl = try configDb
             .collection("namespaces", withType: NamespaceSynchronization.Config.self)
         self.docsColl = try configDb

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/InstanceSynchronizationConfig.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/InstanceSynchronizationConfig.swift
@@ -25,12 +25,12 @@ internal struct InstanceSynchronization: Sequence {
         private let docsColl: MongoCollection<CoreDocumentSynchronization.Config>
         private var values: Values
         private var indices: DefaultIndices<Values>
-        private weak var errorListener: ErrorListener?
+        private weak var errorListener: FatalErrorListener?
 
         init(namespacesColl: MongoCollection<NamespaceSynchronization.Config>,
              docsColl: MongoCollection<CoreDocumentSynchronization.Config>,
              values: Dictionary<MongoNamespace, NamespaceSynchronization.Config>.Values,
-             errorListener: ErrorListener?) {
+             errorListener: FatalErrorListener?) {
             self.namespacesColl = namespacesColl
             self.docsColl = docsColl
             self.values = values
@@ -53,13 +53,13 @@ internal struct InstanceSynchronization: Sequence {
     private let namespacesColl: MongoCollection<NamespaceSynchronization.Config>
     private let docsColl: MongoCollection<CoreDocumentSynchronization.Config>
     private let instanceLock = ReadWriteLock()
-    weak var errorListener: ErrorListener?
+    weak var errorListener: FatalErrorListener?
 
     /// The configuration for this instance.
     private(set) var config: Config
 
     init(configDb: MongoDatabase,
-         errorListener: ErrorListener?) throws {
+         errorListener: FatalErrorListener?) throws {
         self.namespacesColl = try configDb
             .collection("namespaces", withType: NamespaceSynchronization.Config.self)
         self.docsColl = try configDb
@@ -111,7 +111,7 @@ internal struct InstanceSynchronization: Sequence {
                 config.namespaces[namespace] = newConfig.config
                 return newConfig
             } catch {
-                errorListener?.on(error: error, forDocumentId: nil)
+                errorListener?.on(error: error, for: nil, in: namespace)
             }
 
             return nil

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Log.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Log.swift
@@ -1,0 +1,37 @@
+import Foundation
+import os
+
+class Log {
+    private let tag: String
+
+    init(tag: String) {
+        self.tag = tag
+    }
+
+    func i(_ msg: String) {
+        log("%@: %@", type: __OS_LOG_TYPE_INFO, tag, msg)
+    }
+
+    func d(_ msg: String) {
+        log("%@: %@", type: __OS_LOG_TYPE_DEBUG, tag, msg)
+    }
+
+    func e(_ msg: String) {
+        log("%@: %@", type: __OS_LOG_TYPE_ERROR, tag, msg)
+    }
+
+    func f(_ msg: String) {
+        log("%@: %@", type: __OS_LOG_TYPE_FAULT, tag, msg)
+    }
+
+    private func log(_ msg: StaticString,
+                     type: OSLogType = __OS_LOG_TYPE_DEFAULT,
+                     _ args: CVarArg...) {
+        if #available(iOS 10.0, *) {
+            os_log(msg, type: type, args)
+        } else {
+            // Fallback on earlier versions
+            print(String.init(format: msg.description, args))
+        }
+    }
+}

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Log.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Log.swift
@@ -1,25 +1,31 @@
 import Foundation
 import os
 
-class Log {
+/// Basic compat logger
+final class Log {
+    /// Tag to prefix log messages
     private let tag: String
 
     init(tag: String) {
         self.tag = tag
     }
 
+    /// Log info
     func i(_ msg: String) {
         log("%@: %@", type: __OS_LOG_TYPE_INFO, tag, msg)
     }
 
+    /// Log debug
     func d(_ msg: String) {
         log("%@: %@", type: __OS_LOG_TYPE_DEBUG, tag, msg)
     }
 
+    /// Log error
     func e(_ msg: String) {
         log("%@: %@", type: __OS_LOG_TYPE_ERROR, tag, msg)
     }
 
+    /// Log fault
     func f(_ msg: String) {
         log("%@: %@", type: __OS_LOG_TYPE_FAULT, tag, msg)
     }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/NamespaceSynchronizationConfig.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/NamespaceSynchronizationConfig.swift
@@ -159,7 +159,7 @@ internal struct NamespaceSynchronization: Sequence {
                                                            withDocumentId: documentId.bsonValue))
                     config.syncedDocuments[documentId] = nil
                 } catch {
-                    errorListener?.on(error: error, for: documentId.bsonValue.value, in: self.config.namespace)
+                    errorListener?.on(error: error, forDocumentId: documentId.bsonValue.value, in: self.config.namespace)
                 }
                 return
             }
@@ -172,7 +172,7 @@ internal struct NamespaceSynchronization: Sequence {
                     options: ReplaceOptions.init(upsert: true))
                 self.config.syncedDocuments[documentId] = value.config
             } catch {
-                errorListener?.on(error: error, for: documentId.bsonValue.value, in: self.config.namespace)
+                errorListener?.on(error: error, forDocumentId: documentId.bsonValue.value, in: self.config.namespace)
             }
         }
     }
@@ -209,7 +209,7 @@ internal struct NamespaceSynchronization: Sequence {
                     ).compactMap({$0 == nil ? nil : HashableBSONValue($0!)})
                 )
             } catch {
-                errorListener?.on(error: error, for: nil, in: self.config.namespace)
+                errorListener?.on(error: error, forDocumentId: nil, in: self.config.namespace)
                 return Set()
             }
         }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/NamespaceSynchronizationConfig.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/NamespaceSynchronizationConfig.swift
@@ -39,11 +39,11 @@ internal struct NamespaceSynchronization: Sequence {
         private let docsColl: MongoCollection<CoreDocumentSynchronization.Config>
         private var values: Values
         private var indices: DefaultIndices<Values>
-        private weak var errorListener: ErrorListener?
+        private weak var errorListener: FatalErrorListener?
 
         init(docsColl: MongoCollection<CoreDocumentSynchronization.Config>,
              values: Dictionary<HashableBSONValue, CoreDocumentSynchronization.Config>.Values,
-             errorListener: ErrorListener?) {
+             errorListener: FatalErrorListener?) {
             self.docsColl = docsColl
             self.values = values
             self.indices = self.values.indices
@@ -68,7 +68,7 @@ internal struct NamespaceSynchronization: Sequence {
     /// Standard read-write lock.
     private let nsLock: ReadWriteLock = ReadWriteLock()
     /// The error listener to propagate errors to.
-    private weak var errorListener: ErrorListener?
+    private weak var errorListener: FatalErrorListener?
     /// The configuration for this namespace.
     private(set) var config: Config
     /// The conflict handler configured to this namespace.
@@ -86,7 +86,7 @@ internal struct NamespaceSynchronization: Sequence {
     init(namespacesColl: MongoCollection<NamespaceSynchronization.Config>,
          docsColl: MongoCollection<CoreDocumentSynchronization.Config>,
          namespace: MongoNamespace,
-         errorListener: ErrorListener?) throws {
+         errorListener: FatalErrorListener?) throws {
         self.namespacesColl = namespacesColl
         self.docsColl = docsColl
         // read the sync'd document configs from the local collection,
@@ -98,16 +98,17 @@ internal struct NamespaceSynchronization: Sequence {
                 .reduce(into: [HashableBSONValue: CoreDocumentSynchronization.Config](), { (syncedDocuments, config) in
                     syncedDocuments[config.documentId] = config
                 }))
-
+        self.errorListener = errorListener
     }
 
     init(namespacesColl: MongoCollection<NamespaceSynchronization.Config>,
          docsColl: MongoCollection<CoreDocumentSynchronization.Config>,
          config: inout Config,
-         errorListener: ErrorListener?) {
+         errorListener: FatalErrorListener?) {
         self.namespacesColl = namespacesColl
         self.docsColl = docsColl
         self.config = config
+        self.errorListener = errorListener
     }
 
     /// Make an iterator that will iterate over the associated documents.
@@ -156,10 +157,10 @@ internal struct NamespaceSynchronization: Sequence {
                 do {
                     try docsColl.deleteOne(docConfigFilter(forNamespace: config.namespace,
                                                            withDocumentId: documentId.bsonValue))
+                    config.syncedDocuments[documentId] = nil
                 } catch {
-                    errorListener?.on(error: error, forDocumentId: documentId.bsonValue.value)
+                    errorListener?.on(error: error, for: documentId.bsonValue.value, in: self.config.namespace)
                 }
-                config.syncedDocuments[documentId] = nil
                 return
             }
 
@@ -169,10 +170,10 @@ internal struct NamespaceSynchronization: Sequence {
                                             withDocumentId: documentId.bsonValue),
                     replacement: value.config,
                     options: ReplaceOptions.init(upsert: true))
+                self.config.syncedDocuments[documentId] = value.config
             } catch {
-                errorListener?.on(error: error, forDocumentId: documentId.bsonValue.value)
+                errorListener?.on(error: error, for: documentId.bsonValue.value, in: self.config.namespace)
             }
-            self.config.syncedDocuments[documentId] = value.config
         }
     }
 
@@ -208,7 +209,7 @@ internal struct NamespaceSynchronization: Sequence {
                     ).compactMap({$0 == nil ? nil : HashableBSONValue($0!)})
                 )
             } catch {
-                errorListener?.on(error: error, forDocumentId: nil)
+                errorListener?.on(error: error, for: nil, in: self.config.namespace)
                 return Set()
             }
         }

--- a/Core/Services/StitchCoreRemoteMongoDBService/StitchCoreRemoteMongoDBService.xcodeproj/project.pbxproj
+++ b/Core/Services/StitchCoreRemoteMongoDBService/StitchCoreRemoteMongoDBService.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		498E55D02190A05C00A02A03 /* StitchCoreSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 498E55CF2190A05C00A02A03 /* StitchCoreSDK.framework */; };
 		498E55D22190A08400A02A03 /* StitchCoreSDKMocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 498E55D12190A08400A02A03 /* StitchCoreSDKMocks.framework */; };
 		49E8957B21991C1A003C3758 /* NamespaceSynchronizationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E8957A21991C1A003C3758 /* NamespaceSynchronizationConfig.swift */; };
+		49F40F4C21A2FFE500FAB750 /* CoreSyncUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F40F4B21A2FFE500FAB750 /* CoreSyncUnitTests.swift */; };
 		49FA277D219A605700F9E3D4 /* ConflictHandlerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FA277C219A605700F9E3D4 /* ConflictHandlerUnitTests.swift */; };
 		49FA277F219B1F1300F9E3D4 /* ReadWriteLockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FA277E219B1F1300F9E3D4 /* ReadWriteLockTests.swift */; };
 		49FA2781219B2A8900F9E3D4 /* NamespaceSynchronizationConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49FA2780219B2A8900F9E3D4 /* NamespaceSynchronizationConfigTests.swift */; };
@@ -90,6 +91,7 @@
 		498E55CF2190A05C00A02A03 /* StitchCoreSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		498E55D12190A08400A02A03 /* StitchCoreSDKMocks.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreSDKMocks.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		49E8957A21991C1A003C3758 /* NamespaceSynchronizationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamespaceSynchronizationConfig.swift; sourceTree = "<group>"; };
+		49F40F4B21A2FFE500FAB750 /* CoreSyncUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSyncUnitTests.swift; sourceTree = "<group>"; };
 		49FA277C219A605700F9E3D4 /* ConflictHandlerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictHandlerUnitTests.swift; sourceTree = "<group>"; };
 		49FA277E219B1F1300F9E3D4 /* ReadWriteLockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteLockTests.swift; sourceTree = "<group>"; };
 		49FA2780219B2A8900F9E3D4 /* NamespaceSynchronizationConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamespaceSynchronizationConfigTests.swift; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 			children = (
 				49FA2782219B373B00F9E3D4 /* XCMongoMobileTestCase.swift */,
 				498DF590219F73CB009F1B3F /* DataSynchronizerUnitTests.swift */,
+				49F40F4B21A2FFE500FAB750 /* CoreSyncUnitTests.swift */,
 				49FA2786219B6DE500F9E3D4 /* InstanceSynchronizationConfigTests.swift */,
 				49FA2780219B2A8900F9E3D4 /* NamespaceSynchronizationConfigTests.swift */,
 				4943FC6B21968A0900DED08C /* CoreDocumentSynchronizationConfigTests.swift */,
@@ -497,6 +500,7 @@
 				49FA278B219B839F00F9E3D4 /* ChangeEventListenerUnitTests.swift in Sources */,
 				49FA2781219B2A8900F9E3D4 /* NamespaceSynchronizationConfigTests.swift in Sources */,
 				498DF591219F73CB009F1B3F /* DataSynchronizerUnitTests.swift in Sources */,
+				49F40F4C21A2FFE500FAB750 /* CoreSyncUnitTests.swift in Sources */,
 				49FA2785219B656000F9E3D4 /* ChangeEventUnitTests.swift in Sources */,
 				OBJ_201 /* CoreRemoteMongoCollectionUnitTests.swift in Sources */,
 				OBJ_202 /* CoreRemoteMongoDatabaseUnitTests.swift in Sources */,

--- a/Core/Services/StitchCoreRemoteMongoDBService/StitchCoreRemoteMongoDBService.xcodeproj/project.pbxproj
+++ b/Core/Services/StitchCoreRemoteMongoDBService/StitchCoreRemoteMongoDBService.xcodeproj/project.pbxproj
@@ -20,6 +20,10 @@
 		4980B1292199E7E000D6E49C /* ConflictHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4980B1282199E7E000D6E49C /* ConflictHandler.swift */; };
 		4980B12B2199EBE100D6E49C /* ChangeEventListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4980B12A2199EBE100D6E49C /* ChangeEventListener.swift */; };
 		4980B12D219A1AA500D6E49C /* InstanceSynchronizationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4980B12C219A1AA500D6E49C /* InstanceSynchronizationConfig.swift */; };
+		498DF58B219F7393009F1B3F /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498DF58A219F7392009F1B3F /* Log.swift */; };
+		498DF58D219F73AD009F1B3F /* DataSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498DF58C219F73AD009F1B3F /* DataSynchronizer.swift */; };
+		498DF58F219F73B4009F1B3F /* CoreSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498DF58E219F73B4009F1B3F /* CoreSync.swift */; };
+		498DF591219F73CB009F1B3F /* DataSynchronizerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498DF590219F73CB009F1B3F /* DataSynchronizerUnitTests.swift */; };
 		498E55D02190A05C00A02A03 /* StitchCoreSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 498E55CF2190A05C00A02A03 /* StitchCoreSDK.framework */; };
 		498E55D22190A08400A02A03 /* StitchCoreSDKMocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 498E55D12190A08400A02A03 /* StitchCoreSDKMocks.framework */; };
 		49E8957B21991C1A003C3758 /* NamespaceSynchronizationConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E8957A21991C1A003C3758 /* NamespaceSynchronizationConfig.swift */; };
@@ -79,6 +83,10 @@
 		4980B1282199E7E000D6E49C /* ConflictHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictHandler.swift; sourceTree = "<group>"; };
 		4980B12A2199EBE100D6E49C /* ChangeEventListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeEventListener.swift; sourceTree = "<group>"; };
 		4980B12C219A1AA500D6E49C /* InstanceSynchronizationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstanceSynchronizationConfig.swift; sourceTree = "<group>"; };
+		498DF58A219F7392009F1B3F /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
+		498DF58C219F73AD009F1B3F /* DataSynchronizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSynchronizer.swift; sourceTree = "<group>"; };
+		498DF58E219F73B4009F1B3F /* CoreSync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreSync.swift; sourceTree = "<group>"; };
+		498DF590219F73CB009F1B3F /* DataSynchronizerUnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSynchronizerUnitTests.swift; sourceTree = "<group>"; };
 		498E55CF2190A05C00A02A03 /* StitchCoreSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		498E55D12190A08400A02A03 /* StitchCoreSDKMocks.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreSDKMocks.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		49E8957A21991C1A003C3758 /* NamespaceSynchronizationConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NamespaceSynchronizationConfig.swift; sourceTree = "<group>"; };
@@ -157,6 +165,9 @@
 		4943FC592196505500DED08C /* Sync */ = {
 			isa = PBXGroup;
 			children = (
+				498DF58A219F7392009F1B3F /* Log.swift */,
+				498DF58E219F73B4009F1B3F /* CoreSync.swift */,
+				498DF58C219F73AD009F1B3F /* DataSynchronizer.swift */,
 				4980B12C219A1AA500D6E49C /* InstanceSynchronizationConfig.swift */,
 				49E8957A21991C1A003C3758 /* NamespaceSynchronizationConfig.swift */,
 				4943FC622196591F00DED08C /* CoreDocumentSynchronizationConfig.swift */,
@@ -177,6 +188,7 @@
 			isa = PBXGroup;
 			children = (
 				49FA2782219B373B00F9E3D4 /* XCMongoMobileTestCase.swift */,
+				498DF590219F73CB009F1B3F /* DataSynchronizerUnitTests.swift */,
 				49FA2786219B6DE500F9E3D4 /* InstanceSynchronizationConfigTests.swift */,
 				49FA2780219B2A8900F9E3D4 /* NamespaceSynchronizationConfigTests.swift */,
 				4943FC6B21968A0900DED08C /* CoreDocumentSynchronizationConfigTests.swift */,
@@ -447,6 +459,7 @@
 				4980B1292199E7E000D6E49C /* ConflictHandler.swift in Sources */,
 				4943FC6F219724E800DED08C /* DocumentVersionInfo.swift in Sources */,
 				49037A44219E0ECD0066E109 /* ErrorListener.swift in Sources */,
+				498DF58B219F7393009F1B3F /* Log.swift in Sources */,
 				OBJ_170 /* CoreRemoteMongoCursor.swift in Sources */,
 				OBJ_171 /* CoreRemoteMongoDatabase.swift in Sources */,
 				OBJ_172 /* CoreRemoteMongoReadOperation.swift in Sources */,
@@ -457,9 +470,11 @@
 				4943FC5D2196508100DED08C /* MongoNamespace.swift in Sources */,
 				4943FC61219650A200DED08C /* UpdateDescription.swift in Sources */,
 				OBJ_175 /* RemoteFindOptions.swift in Sources */,
+				498DF58F219F73B4009F1B3F /* CoreSync.swift in Sources */,
 				OBJ_176 /* RemoteInsertManyResult.swift in Sources */,
 				49E8957B21991C1A003C3758 /* NamespaceSynchronizationConfig.swift in Sources */,
 				OBJ_177 /* RemoteInsertOneResult.swift in Sources */,
+				498DF58D219F73AD009F1B3F /* DataSynchronizer.swift in Sources */,
 				4980B12D219A1AA500D6E49C /* InstanceSynchronizationConfig.swift in Sources */,
 				OBJ_178 /* RemoteUpdateOptions.swift in Sources */,
 				4980B12B2199EBE100D6E49C /* ChangeEventListener.swift in Sources */,
@@ -481,6 +496,7 @@
 				49FA278D219B84F400F9E3D4 /* DocumentVersionInfoUnitTests.swift in Sources */,
 				49FA278B219B839F00F9E3D4 /* ChangeEventListenerUnitTests.swift in Sources */,
 				49FA2781219B2A8900F9E3D4 /* NamespaceSynchronizationConfigTests.swift in Sources */,
+				498DF591219F73CB009F1B3F /* DataSynchronizerUnitTests.swift in Sources */,
 				49FA2785219B656000F9E3D4 /* ChangeEventUnitTests.swift in Sources */,
 				OBJ_201 /* CoreRemoteMongoCollectionUnitTests.swift in Sources */,
 				OBJ_202 /* CoreRemoteMongoDatabaseUnitTests.swift in Sources */,

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/CoreDocumentSynchronizationConfigTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/CoreDocumentSynchronizationConfigTests.swift
@@ -72,9 +72,9 @@ class CoreDocumentSynchronizationConfigTests: XCMongoMobileTestCase {
 
         var decodedCoreDocConfig = try BSONDecoder().decode(CoreDocumentSynchronization.Config.self,
                                                             from: encodedCoreDocSync)
-        let decodedCoreDocSync = try CoreDocumentSynchronization.init(docsColl: docsColl,
-                                                                      config: &decodedCoreDocConfig,
-                                                                      errorListener: nil)
+        let decodedCoreDocSync = CoreDocumentSynchronization.init(docsColl: docsColl,
+                                                                  config: &decodedCoreDocConfig,
+                                                                  errorListener: nil)
 
         XCTAssertEqual(isPaused, decodedCoreDocSync.isPaused)
         XCTAssertEqual(isStale, decodedCoreDocSync.isStale)

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/CoreSyncUnitTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/CoreSyncUnitTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import MongoSwift
+import XCTest
+@testable import StitchCoreRemoteMongoDBService
+class CoreSyncUnitTests: XCMongoMobileTestCase {
+    private let instanceKey = ObjectId()
+    private let namespace = MongoNamespace.init(databaseName: "db", collectionName: "coll")
+
+    private lazy var dataSynchronizer = DataSynchronizerUnitTests.dataSynchronizer(
+        withInstanceKey: instanceKey
+    )
+    private lazy var coreSync = CoreSync<Document>.init(namespace: namespace,
+                                                        dataSynchronizer: dataSynchronizer)
+
+    override func tearDown() {
+        try? XCMongoMobileTestCase.client.db("sync_config" + instanceKey.oid).drop()
+    }
+    
+    func testConfigure() {
+        XCTAssertFalse(dataSynchronizer.isConfigured)
+        coreSync.configure(conflictHandler: DataSynchronizerUnitTests.TestConflictHandler(),
+                           changeEventListener: DataSynchronizerUnitTests.TestEventListener(),
+                           errorListener: DataSynchronizerUnitTests.TestErrorListener())
+        XCTAssertTrue(dataSynchronizer.isConfigured)
+        XCTAssertTrue(dataSynchronizer.isRunning)
+    }
+
+    func testSync_SyncedIds_Desync() {
+        let ids = [ObjectId(), ObjectId()]
+
+        coreSync.sync(ids: ids)
+        XCTAssertEqual(Set(ids.map { HashableBSONValue($0) }),
+                       dataSynchronizer.syncedIds(in: namespace))
+        XCTAssertEqual(Set(ids.map { HashableBSONValue($0) }),
+                       coreSync.syncedIds)
+
+        coreSync.desync(ids: ids)
+        XCTAssertEqual(Set(),
+                       dataSynchronizer.syncedIds(in: namespace))
+        XCTAssertEqual(Set(),
+                       coreSync.syncedIds)
+    }
+}

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/DataSynchronizerUnitTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/DataSynchronizerUnitTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import StitchCoreSDK
+import StitchCoreSDKMocks
+import XCTest
+import MongoSwift
+@testable import StitchCoreRemoteMongoDBService
+
+class DataSynchronizerUnitTests: XCMongoMobileTestCase {
+    let mockServiceClient = MockCoreStitchServiceClient.init()
+    class TestNetworkMonitor: NetworkMonitor {
+        var networkStateListeners = [NetworkStateListener]()
+
+        func isConnected() -> Bool {
+            return true
+        }
+
+        func add(networkStateListener listener: NetworkStateListener) {
+            self.networkStateListeners.append(listener)
+        }
+
+        func remove(networkStateListener listener: NetworkStateListener) {
+            if let index = self.networkStateListeners.firstIndex(where: { $0 === listener }) {
+                self.networkStateListeners.remove(at: index)
+            }
+        }
+    }
+
+    class TestAuthMonitor: AuthMonitor {
+        func isLoggedIn() -> Bool {
+            return true
+        }
+    }
+
+    class TestConflictHandler: ConflictHandler {
+        typealias DocumentT = Document
+        func resolveConflict(documentId: BSONValue,
+                             localEvent: ChangeEvent<Document>,
+                             remoteEvent: ChangeEvent<Document>) throws -> Document? {
+            return remoteEvent.fullDocument
+        }
+    }
+
+    class TestErrorListener: ErrorListener {
+        func on(error: Error, forDocumentId documentId: BSONValue?) {
+        }
+    }
+
+    class TestEventListener: ChangeEventListener {
+        typealias DocumentT = Document
+        func onEvent(documentId: BSONValue,
+                     event: ChangeEvent<Document>) {
+        }
+    }
+
+    let instanceKey = ObjectId()
+    lazy var dataSynchronizer = try! DataSynchronizer.init(
+        instanceKey: instanceKey.oid,
+        service: MockCoreStitchServiceClient.init(),
+        localClient: XCMongoMobileTestCase.client,
+        remoteClient: CoreRemoteMongoClient.init(withService: mockServiceClient),
+        networkMonitor: TestNetworkMonitor(),
+        authMonitor: TestAuthMonitor())
+    let namespace = MongoNamespace.init(databaseName: "db", collectionName: "coll")
+
+    override func tearDown() {
+        try? XCMongoMobileTestCase.client.db("sync_config" + instanceKey.oid).drop()
+    }
+
+    func testStart_Stop() {
+        XCTAssertFalse(dataSynchronizer.isRunning)
+        
+        dataSynchronizer.start()
+
+        XCTAssertTrue(dataSynchronizer.isRunning)
+
+        dataSynchronizer.stop()
+
+        XCTAssertFalse(dataSynchronizer.isRunning)
+    }
+
+    func testSync_SyncedIds_Desync() {
+        let ids = [ObjectId(), ObjectId()]
+
+        dataSynchronizer.sync(ids: ids, in: namespace)
+        XCTAssertEqual(Set(ids.map { HashableBSONValue($0) }),
+                       dataSynchronizer.syncedIds(in: namespace))
+
+        dataSynchronizer.desync(ids: ids, in: namespace)
+        XCTAssertEqual(Set(),
+                       dataSynchronizer.syncedIds(in: namespace))
+    }
+
+    func testConfigure_ReloadConfig() throws {
+        dataSynchronizer.configure(namespace: namespace,
+                                   conflictHandler: TestConflictHandler(),
+                                   changeEventListener: TestEventListener(),
+                                   errorListener: TestErrorListener())
+        XCTAssertTrue(dataSynchronizer.isRunning)
+
+        try dataSynchronizer.reloadConfig()
+
+        XCTAssertFalse(dataSynchronizer.isRunning)
+    }
+}

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/InstanceSynchronizationConfigTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/InstanceSynchronizationConfigTests.swift
@@ -41,14 +41,14 @@ class InstanceSynchronizationConfigTests: XCMongoMobileTestCase, ErrorListener {
 
         XCTAssertEqual(instanceSync[namespace]?.config.namespace, nsConfig.config.namespace)
 
-        let documentId = HashableBSONValue(ObjectId())
+        let documentId = ObjectId()
         var nsConfig2 = instanceSync[namespace2]
         nsConfig2?[documentId] = CoreDocumentSynchronization.init(docsColl: docsColl,
                                                                   namespace: namespace2,
-                                                                  documentId: documentId.bsonValue,
+                                                                  documentId: AnyBSONValue(documentId),
                                                                   errorListener: nil)
 
         XCTAssertEqual(2, instanceSync.map { $0 }.count)
-        XCTAssertEqual(documentId, HashableBSONValue((instanceSync[namespace2]?[documentId]?.documentId)!))
+        XCTAssertEqual(documentId, instanceSync[namespace2]?[documentId]?.documentId.value as? ObjectId)
     }
 }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/InstanceSynchronizationConfigTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/InstanceSynchronizationConfigTests.swift
@@ -4,7 +4,7 @@ import MongoSwift
 import XCTest
 @testable import StitchCoreRemoteMongoDBService
 
-class InstanceSynchronizationConfigTests: XCMongoMobileTestCase, ErrorListener {
+class InstanceSynchronizationConfigTests: XCMongoMobileTestCase, FatalErrorListener {
     private var namespaceColl: MongoCollection<NamespaceSynchronization.Config>!
     private var docsColl: MongoCollection<CoreDocumentSynchronization.Config>!
 
@@ -24,8 +24,8 @@ class InstanceSynchronizationConfigTests: XCMongoMobileTestCase, ErrorListener {
         try? XCMongoMobileTestCase.client.db(namespace.databaseName).drop()
     }
 
-    func on(error: Error, forDocumentId documentId: BSONValue?) {
-
+    func on(error: Error, for documentId: BSONValue?, in namespace: MongoNamespace?) {
+        XCTFail(error.localizedDescription)
     }
 
     func testGet_Set_ModifyInPlace() throws {

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/InstanceSynchronizationConfigTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/InstanceSynchronizationConfigTests.swift
@@ -24,7 +24,7 @@ class InstanceSynchronizationConfigTests: XCMongoMobileTestCase, FatalErrorListe
         try? XCMongoMobileTestCase.client.db(namespace.databaseName).drop()
     }
 
-    func on(error: Error, for documentId: BSONValue?, in namespace: MongoNamespace?) {
+    func on(error: Error, forDocumentId documentId: BSONValue?, in namespace: MongoNamespace?) {
         XCTFail(error.localizedDescription)
     }
 

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/NamespaceSynchronizationConfigTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/NamespaceSynchronizationConfigTests.swift
@@ -48,11 +48,11 @@ class NamespaceSynchronizationConfigTests: XCMongoMobileTestCase {
     }
 
     func testStaleDocumentIds() throws {
-        class TestErrorListener: ErrorListener {
+        class TestErrorListener: FatalErrorListener {
             public init() {
             }
 
-            func on(error: Error, forDocumentId documentId: BSONValue?) {
+            func on(error: Error, for documentId: BSONValue?, in namespace: MongoNamespace?) {
                 XCTFail(error.localizedDescription)
             }
         }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/NamespaceSynchronizationConfigTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/NamespaceSynchronizationConfigTests.swift
@@ -52,7 +52,7 @@ class NamespaceSynchronizationConfigTests: XCMongoMobileTestCase {
             public init() {
             }
 
-            func on(error: Error, for documentId: BSONValue?, in namespace: MongoNamespace?) {
+            func on(error: Error, forDocumentId documentId: BSONValue?, in namespace: MongoNamespace?) {
                 XCTFail(error.localizedDescription)
             }
         }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/NamespaceSynchronizationConfigTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/NamespaceSynchronizationConfigTests.swift
@@ -23,7 +23,7 @@ class NamespaceSynchronizationConfigTests: XCMongoMobileTestCase {
     }
 
     func testSet() throws {
-        let documentId = HashableBSONValue(ObjectId())
+        let documentId = ObjectId()
         var nsConfig = try NamespaceSynchronization.init(namespacesColl: namespaceColl,
                                                          docsColl: docsColl,
                                                          namespace: namespace,
@@ -35,7 +35,7 @@ class NamespaceSynchronizationConfigTests: XCMongoMobileTestCase {
 
         docConfig = CoreDocumentSynchronization.init(docsColl: docsColl,
                                                      namespace: namespace,
-                                                     documentId: documentId.bsonValue,
+                                                     documentId: AnyBSONValue(documentId),
                                                      errorListener: nil)
 
         nsConfig[documentId] = docConfig
@@ -84,7 +84,7 @@ class NamespaceSynchronizationConfigTests: XCMongoMobileTestCase {
                                              errorListener: errorListener)
         ]
 
-        docConfigs.forEach { nsConfig[HashableBSONValue($0.documentId)] = $0 }
+        docConfigs.forEach { nsConfig[$0.documentId.value] = $0 }
 
         docConfigs[1].isStale = true
 

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Common/AuthMonitor.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Common/AuthMonitor.swift
@@ -1,0 +1,3 @@
+public protocol AuthMonitor {
+    func isLoggedIn() -> Bool
+}

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Net/NetworkMonitor.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Net/NetworkMonitor.swift
@@ -1,0 +1,11 @@
+public protocol NetworkMonitor {
+    func isConnected() -> Bool
+
+    func add(networkStateListener listener: NetworkStateListener)
+
+    func remove(networkStateListener listener: NetworkStateListener)
+}
+
+public protocol NetworkStateListener: class {
+    func onNetworkStateChanged()
+}

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/StitchError.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/StitchError.swift
@@ -109,6 +109,7 @@ public enum StitchClientErrorCode {
     case userNoLongerValid
     case couldNotLoadPersistedAuthInfo
     case couldNotPersistAuthInfo
+    case couldNotLoadSyncInfo
 }
 
 /**

--- a/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
+++ b/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		498062C52185B6C300E2A3A2 /* MockCoreStitchServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498061FA2185B6A100E2A3A2 /* MockCoreStitchServiceClient.swift */; };
 		498062C62185B6C300E2A3A2 /* SpyCoreStitchServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498061FB2185B6A100E2A3A2 /* SpyCoreStitchServiceClient.swift */; };
 		498062F82185C53A00E2A3A2 /* MockUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 498062F72185C53A00E2A3A2 /* MockUtils.framework */; };
+		498DF593219F7451009F1B3F /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498DF592219F7451009F1B3F /* NetworkMonitor.swift */; };
+		498DF595219F748D009F1B3F /* AuthMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498DF594219F748D009F1B3F /* AuthMonitor.swift */; };
 		50DD6C42B999287408B28A87 /* Pods_StitchCoreSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7208856FB724F1294EEF8EEF /* Pods_StitchCoreSDK.framework */; };
 		68122848856ABD3AA0CCEAD9 /* Pods_StitchCoreSDKMocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 392DB4A470DD46E0E6B78130 /* Pods_StitchCoreSDKMocks.framework */; };
 /* End PBXBuildFile section */
@@ -217,6 +219,8 @@
 		4980626B2185B6AF00E2A3A2 /* StitchClientConfigurationUnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StitchClientConfigurationUnitTests.swift; sourceTree = "<group>"; };
 		4980626E2185B6AF00E2A3A2 /* CoreStitchServiceClientUnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreStitchServiceClientUnitTests.swift; sourceTree = "<group>"; };
 		498062F72185C53A00E2A3A2 /* MockUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MockUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		498DF592219F7451009F1B3F /* NetworkMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
+		498DF594219F748D009F1B3F /* AuthMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthMonitor.swift; sourceTree = "<group>"; };
 		56A941B0C77E12887F13038D /* Pods-StitchCoreSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDKTests.release.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDKTests/Pods-StitchCoreSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		7208856FB724F1294EEF8EEF /* Pods_StitchCoreSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StitchCoreSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC64CB22BA4E530CF65F9EAF /* Pods-StitchCoreSDKMocks.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDKMocks.debug.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDKMocks/Pods-StitchCoreSDKMocks.debug.xcconfig"; sourceTree = "<group>"; };
@@ -518,6 +522,7 @@
 		498062372185B6A100E2A3A2 /* Net */ = {
 			isa = PBXGroup;
 			children = (
+				498DF592219F7451009F1B3F /* NetworkMonitor.swift */,
 				498062382185B6A100E2A3A2 /* StitchRequestClient.swift */,
 				498062392185B6A100E2A3A2 /* Transport.swift */,
 				4980623A2185B6A100E2A3A2 /* FoundationHTTPTransport.swift */,
@@ -545,6 +550,7 @@
 		498062452185B6A100E2A3A2 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				498DF594219F748D009F1B3F /* AuthMonitor.swift */,
 				498062462185B6A100E2A3A2 /* Storage.swift */,
 				498062472185B6A100E2A3A2 /* ImplFailureFatalErrors.swift */,
 			);
@@ -1033,12 +1039,14 @@
 				498062B32185B6BC00E2A3A2 /* Request.swift in Sources */,
 				498062B42185B6BC00E2A3A2 /* StitchAuthRequest.swift in Sources */,
 				498062B52185B6BC00E2A3A2 /* Method.swift in Sources */,
+				498DF593219F7451009F1B3F /* NetworkMonitor.swift in Sources */,
 				498062B62185B6BC00E2A3A2 /* ContentType.swift in Sources */,
 				498062B72185B6BC00E2A3A2 /* Storage.swift in Sources */,
 				498062B82185B6BC00E2A3A2 /* ImplFailureFatalErrors.swift in Sources */,
 				498062B92185B6BC00E2A3A2 /* CoreStitchAppClient.swift in Sources */,
 				498062BA2185B6BC00E2A3A2 /* CoreStitchPushClient.swift in Sources */,
 				498062BB2185B6BC00E2A3A2 /* StitchPushRoutes.swift in Sources */,
+				498DF595219F748D009F1B3F /* AuthMonitor.swift in Sources */,
 				498062BC2185B6BC00E2A3A2 /* CoreStitchPushClientImpl.swift in Sources */,
 				498062BD2185B6BC00E2A3A2 /* StitchError.swift in Sources */,
 				498062BE2185B6BC00E2A3A2 /* CoreStitchServiceClientImpl.swift in Sources */,


### PR DESCRIPTION
Add the skeletons for CoreSync and DataSynchronizer. We (essentially) get the entirety CoreSync here for free, since on Swift, it is a simple delegate for the DataSynchronizer.

This includes the NetworkMonitor and AuthMonitor protocols.

I've also added an internal FatalErrorListener for the arbitrary lower-level errors that can occur due to MongoSwift or otherwise. It is meant to listen for "impossible states", and will pass along whatever information it can to the user.

Though the PR seems large, much of it is tests/comments, and many of the DataSynchronizer methods are stubs. This should allow us to not step on each other for future tickets.