### PR TITLE
STITCH-2008 - code complete ios changes to support location lookup fo…

### DIFF
--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Net/AppMetadata.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Net/AppMetadata.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Application Metadata
+public final class AppMetadata: Codable, CustomStringConvertible {
+    let deploymentModel: String
+    let location: String
+    let hostname: String
+    
+    public var description: String {
+        let encoder = JSONEncoder()
+        
+        guard let data = try? encoder.encode(self),
+              let str = String(data: data, encoding: .utf8) else {
+            return "<json serialization error>"
+        }
+        return str
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case deploymentModel = "deployment_model"
+        case location
+        case hostname
+    }
+}

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Net/StitchAppRoutes.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Net/StitchAppRoutes.swift
@@ -4,10 +4,11 @@
 internal final class StitchAppRouteParts {
     static let baseRoute = "/api/client/v2.0"
     static let appRoute = baseRoute + "/app/%@"
+    static let appMetadataRoute = appRoute + "/location"
     static let functionCallRoute = appRoute + "/functions/call"
     static let baseAuthRoute = baseRoute + "/auth"
     static let baseAppAuthRoute = appRoute + "/auth"
-
+    
     static let sessionRoute = baseAuthRoute + "/session"
     static let profileRoute = baseAuthRoute + "/profile"
     static let authProviderRoute = baseAppAuthRoute + "/providers/%@"
@@ -23,27 +24,27 @@ public protocol StitchAuthRoutes {
      * The route on the server for getting a new access token.
      */
     var sessionRoute: String { get }
-
+    
     /**
      * The route on the server for fetching the currently authenticated user's profile.
      */
     var profileRoute: String { get }
-
+    
     /**
      * The base route on the server for authentication-related actions.
      */
     var baseAuthRoute: String { get }
-
+    
     /**
      * Returns the route on the server for getting information about a particular authentication provider.
      */
     func authProviderRoute(withProviderName providerName: String) -> String
-
+    
     /**
      * Returns the route on the server for logging in with a particular authentication provider.
      */
     func authProviderLoginRoute(withProviderName providerName: String) -> String
-
+    
     /**
      * Returns the route on the server for linking the currently authenticated user with an identity associated with a
      * particular authentication provider.
@@ -59,14 +60,20 @@ public final class StitchServiceRoutes {
      * The client app id of the app that these routes are for.
      */
     private let clientAppID: String
-
+    
     /**
      * Initializes these routes with the provided client app id.
      */
     fileprivate init(clientAppID: String) {
         self.clientAppID = clientAppID
     }
-
+    
+    /**
+     * Returns the route on the server for discovering application metadata.
+     */
+    public lazy var appMetadataRoute = String.init(format: StitchAppRouteParts.appMetadataRoute,
+                                              self.clientAppID)
+    
     /**
      * Returns the route on the server for executing a function.
      */
@@ -82,29 +89,29 @@ public struct StitchAppAuthRoutes: StitchAuthRoutes {
      * The client app id of the app that these routes are for.
      */
     private let clientAppID: String
-
+    
     /**
      * The route on the server for getting a new access token.
      */
     public var sessionRoute: String = StitchAppRouteParts.sessionRoute
-
+    
     /**
      * The route on the server for fetching the currently authenticated user's profile.
      */
     public var profileRoute: String = StitchAppRouteParts.profileRoute
-
+    
     /**
      * The route on the server for creating and modifying user API keys.
      */
     public var baseAuthRoute: String = StitchAppRouteParts.baseAuthRoute
-
+    
     /**
      * Initializes these routes with the provided client app id.
      */
     fileprivate init(clientAppID: String) {
         self.clientAppID = clientAppID
     }
-
+    
     /**
      * Returns the route on the server for getting information about a particular authentication provider.
      */
@@ -113,7 +120,7 @@ public struct StitchAppAuthRoutes: StitchAuthRoutes {
                            self.clientAppID,
                            providerName)
     }
-
+    
     /**
      * Returns the route on the server for logging in with a particular authentication provider.
      */
@@ -122,7 +129,7 @@ public struct StitchAppAuthRoutes: StitchAuthRoutes {
                            self.clientAppID,
                            providerName)
     }
-
+    
     /**
      * Returns the route on the server for linking the currently authenticated user with an identity associated with a
      * particular authentication provider.
@@ -142,7 +149,7 @@ public final class StitchAppRoutes {
      * Returns the authentication routes for the current app.
      */
     public let authRoutes: StitchAppAuthRoutes
-
+    
     /**
      * Returns the service routes for the current app.
      */
@@ -152,7 +159,7 @@ public final class StitchAppRoutes {
      * Returns the push routes for the current app.
      */
     public let pushRoutes: StitchPushRoutes
-
+    
     /**
      * Initializes the app routes with the provided client app id.
      */
@@ -162,3 +169,4 @@ public final class StitchAppRoutes {
         self.pushRoutes = StitchPushRoutes.init(clientAppID: clientAppID)
     }
 }
+

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Net/StitchRequestClient.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Internal/Net/StitchRequestClient.swift
@@ -7,9 +7,9 @@ import MongoSwift
 private func inspectResponse(response: Response) throws -> Response {
     guard response.statusCode >= 200,
         response.statusCode < 300 else {
-        throw StitchErrorCodable.handleError(forResponse: response)
+            throw StitchErrorCodable.handleError(forResponse: response)
     }
-
+    
     return response
 }
 
@@ -18,9 +18,23 @@ private func inspectResponse(response: Response) throws -> Response {
  */
 public protocol StitchRequestClient {
     /**
-     * Initializes the request client with the provided base URL and `Transport`.
+     * The base URL of the Stitch server to which this client will retrieve metadata.
      */
-    init(baseURL: String, transport: Transport, defaultRequestTimeout: TimeInterval)
+    var baseURL: String { get }
+    
+    /**
+     * The `Transport` which this client will use to make round trips to the Stitch server.
+     */
+    var transport: Transport { get }
+    
+    /**
+     * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
+     * error.
+     *
+     * - important: If a request timeout was specified for a specific operation, for example in a function call, that
+     *              timeout should override this one.
+     */
+    var defaultRequestTimeout: TimeInterval { get }
 
     /**
      * Performs a request against the Stitch server with the given `StitchRequest` object.
@@ -30,20 +44,48 @@ public protocol StitchRequestClient {
     func doRequest(_ stitchReq: StitchRequest) throws -> Response
 }
 
-/**
- * The implementation of `StitchRequestClient`.
- */
-public final class StitchRequestClientImpl: StitchRequestClient {
+extension StitchRequestClient {
+    func doRequest(_ stitchReq: StitchRequest, url: String) throws -> Response {
+        var response: Response!
+        do {
+            response = try self.transport.roundTrip(request: self.buildRequest(stitchReq, url: url))
+        } catch {
+            // Wrap the error from the transport in a `StitchError.requestError`
+            throw StitchError.requestError(withError: error, withRequestErrorCode: .transportError)
+        }
+        return try inspectResponse(response: response)
+    }
+    
     /**
-     * The base URL of the Stitch server to which this client will make requests.
+     * Builds a plain HTTP request out of the provided `StitchRequest` object.
      */
-    private let baseURL: String
+    private func buildRequest(_ stitchReq: StitchRequest, url: String) throws -> Request {
+        let reqBuilder = RequestBuilder()
+            .with(method: stitchReq.method)
+            .with(url: "\(url)\(stitchReq.path)")
+            .with(timeout: stitchReq.timeout ?? self.defaultRequestTimeout)
+            .with(headers: stitchReq.headers)
+            .with(body: stitchReq.body)
+        
+        return try reqBuilder.build()
+    }
+}
 
+/**
+ * An implementation of `StitchRequestClient` that builds on `StitchRequestClientImpl` to
+ * add the ability to use a client application ID to target location-specific endpoints.
+ */
+public class StitchAppRequestClientImpl: StitchRequestClient {
+    /**
+     * The base URL of the Stitch server to which this client will retrieve metadata.
+     */
+    public let baseURL: String
+    
     /**
      * The `Transport` which this client will use to make round trips to the Stitch server.
      */
-    private let transport: Transport
-
+    public let transport: Transport
+    
     /**
      * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
      * error.
@@ -51,44 +93,107 @@ public final class StitchRequestClientImpl: StitchRequestClient {
      * - important: If a request timeout was specified for a specific operation, for example in a function call, that
      *              timeout should override this one.
      */
-    private let defaultRequestTimeout: TimeInterval
+    public let defaultRequestTimeout: TimeInterval
+    
+    /**
+     * The client application ID for the application.
+     */
+    private let clientAppId: String
+    
+    /**
+     * Route constants used to path requests properly.
+     */
+    private let appRoutes: StitchAppRoutes
 
+    /**
+     * The application metadata as discovered by communicating with the server.
+     */
+    private var appMetadata: AppMetadata?
+    
+    /**
+     * Initializes the request client with the provided client app ID, base URL and `Transport`.
+     */
+    public init(clientAppId: String, baseURL: String, transport: Transport,
+                defaultRequestTimeout: TimeInterval) {
+        self.clientAppId = clientAppId
+        self.baseURL = baseURL
+        self.transport = transport
+        self.defaultRequestTimeout = defaultRequestTimeout
+        self.appRoutes = StitchAppRoutes.init(clientAppID: clientAppId)
+    }
+    
+    /**
+     * Performs a request against the Stitch server with the given `StitchRequest` object. Uses
+     * the local stitch hostname provided by the server instead of the base URL.
+     *
+     * - returns: the response to the request as a `Response` object.
+     */
+    public func doRequest(_ stitchReq: StitchRequest) throws -> Response {
+        try self.initAppMetadata()
+        return try doRequest(stitchReq, url: self.appMetadata!.hostname)
+    }
+    
+    func initAppMetadata() throws {
+        guard appMetadata == nil else {
+            return
+        }
+        
+        let req = StitchRequest.init(path: self.appRoutes.serviceRoutes.appMetadataRoute,
+                                     method: Method.get, headers: [:],
+                                     timeout: self.defaultRequestTimeout, body: nil)
+        
+        let decoder = JSONDecoder()
+        do {
+            let response = try doRequest(req, url: self.baseURL)
+            guard let body = response.body else {
+                throw StitchError.requestError(withMessage: "empty body in location metadata", withRequestErrorCode: .decodingError)
+            }
+            self.appMetadata = try decoder.decode(AppMetadata.self, from: body)
+        } catch {
+            throw StitchError.requestError(withError: error, withRequestErrorCode: .bootstrapError)
+        }
+    }
+}
+
+/**
+ * The implementation of `StitchRequestClient`.
+ */
+public class StitchRequestClientImpl: StitchRequestClient {
+    /**
+     * The base URL of the Stitch server to which this client will make requests.
+     */
+    public let baseURL: String
+    
+    /**
+     * The `Transport` which this client will use to make round trips to the Stitch server.
+     */
+    public let transport: Transport
+    
+    /**
+     * The number of seconds that a `Transport` should spend by default on an HTTP round trip before failing with an
+     * error.
+     *
+     * - important: If a request timeout was specified for a specific operation, for example in a function call, that
+     *              timeout should override this one.
+     */
+    public let defaultRequestTimeout: TimeInterval
+    
     /**
      * Initializes the request client with the provided base URL and `Transport`.
      */
-    public init(baseURL: String, transport: Transport, defaultRequestTimeout: TimeInterval) {
+    public required init(baseURL: String, transport: Transport, defaultRequestTimeout: TimeInterval) {
         self.baseURL = baseURL
         self.transport = transport
         self.defaultRequestTimeout = defaultRequestTimeout
     }
-
+    
     /**
      * Performs a request against the Stitch server with the given `StitchRequest` object.
      *
      * - returns: the response to the request as a `Response` object.
      */
     public func doRequest(_ stitchReq: StitchRequest) throws -> Response {
-        var response: Response!
-        do {
-            response = try self.transport.roundTrip(request: self.buildRequest(stitchReq))
-        } catch {
-            // Wrap the error from the transport in a `StitchError.requestError`
-            throw StitchError.requestError(withError: error, withRequestErrorCode: .transportError)
-        }
-        return try inspectResponse(response: response)
-    }
-
-    /**
-     * Builds a plain HTTP request out of the provided `StitchRequest` object.
-     */
-    private func buildRequest(_ stitchReq: StitchRequest) throws -> Request {
-        let reqBuilder = RequestBuilder()
-            .with(method: stitchReq.method)
-            .with(url: "\(self.baseURL)\(stitchReq.path)")
-            .with(timeout: stitchReq.timeout ?? self.defaultRequestTimeout)
-            .with(headers: stitchReq.headers)
-            .with(body: stitchReq.body)
-
-        return try reqBuilder.build()
+        return try doRequest(stitchReq, url: self.baseURL)
     }
 }
+

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/StitchError.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/StitchError.swift
@@ -24,8 +24,18 @@ public enum StitchError: Error {
      * thrown when attempting to decode the response. An error code is included, which indicates whether the error
      * was a transport error or decoding error.
      */
-    case requestError(withError: Error, withRequestErrorCode: StitchRequestErrorCode)
+    case requestError(withMessage: String, withRequestErrorCode: StitchRequestErrorCode)
 
+    /**
+     * Indicates that an error occurred while a request was being carried out. This could be due to (but is not
+     * limited to) an unreachable server, a connection timeout, or an inability to decode the result. In the case of
+     * transport errors, these errors are thrown by the underlying `Transport` of the Stitch client, and thus contain
+     * the error that the transport threw. Errors in decoding the result from the server include the specific error
+     * thrown when attempting to decode the response. An error code is included, which indicates whether the error
+     * was a transport error or decoding error.
+     */
+    case requestError(withError: Error, withRequestErrorCode: StitchRequestErrorCode)
+    
     /**
      * Indicates that an error occurred when using the Stitch client, typically before the client performed a request.
      * An error code indicating the reason for the error is included.
@@ -95,6 +105,7 @@ public enum StitchRequestErrorCode {
     case transportError
     case decodingError
     case encodingError
+    case bootstrapError
     case unknownError
 }
 

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDKMocks/Auth/Internal/MockCoreStitchAuth.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDKMocks/Auth/Internal/MockCoreStitchAuth.swift
@@ -24,9 +24,17 @@ public struct StubAuthRoutes: StitchAuthRoutes {
 }
 
 public final class StubStitchRequestClient: StitchRequestClient {
-    public init() { }
+    public let baseURL: String
     
-    public init(baseURL: String, transport: Transport, defaultRequestTimeout: TimeInterval) { }
+    public let transport: Transport
+    
+    public let defaultRequestTimeout: TimeInterval
+    
+    public init() {
+        baseURL = ""
+        transport = MockTransport()
+        defaultRequestTimeout = 0
+    }
     
     public func doRequest(_ stitchReq: StitchRequest) throws -> Response {
         return Response.init(statusCode: 500, headers: [:], body: nil)

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDKMocks/Internal/MockStitchRequestClient.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDKMocks/Internal/MockStitchRequestClient.swift
@@ -3,14 +3,18 @@ import MockUtils
 @testable import StitchCoreSDK
 
 public final class MockStitchRequestClient: StitchRequestClient {
+    public let baseURL: String
+    
+    public let transport: Transport
+    
+    public let defaultRequestTimeout: TimeInterval
+    
     public init() {
-        // do nothing
+        self.baseURL = ""
+        self.transport = MockTransport()
+        self.defaultRequestTimeout = 0
     }
-    
-    public init(baseURL: String, transport: Transport, defaultRequestTimeout: TimeInterval) {
-        // do nothing
-    }
-    
+        
     public var doRequestMock = FunctionMockUnitOneArg<Response, StitchRequest>()
     public func doRequest(_ stitchReq: StitchRequest) throws -> Response {
         return try doRequestMock.throwingRun(arg1: stitchReq)

--- a/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
+++ b/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
@@ -96,6 +96,7 @@
 		498062C62185B6C300E2A3A2 /* SpyCoreStitchServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498061FB2185B6A100E2A3A2 /* SpyCoreStitchServiceClient.swift */; };
 		498062F82185C53A00E2A3A2 /* MockUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 498062F72185C53A00E2A3A2 /* MockUtils.framework */; };
 		840CE3539851FCE84B2E121E /* Pods_StitchCoreSDKTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 363D0185C367AB395C01ED51 /* Pods_StitchCoreSDKTests.framework */; };
+		912E51E321A4B6BC00D50CA6 /* AppMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912E51E221A4B6BC00D50CA6 /* AppMetadata.swift */; };
 		B5071457C06B240A008C7EE2 /* Pods_StitchCoreSDKMocks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63522D459717B507643396EF /* Pods_StitchCoreSDKMocks.framework */; };
 /* End PBXBuildFile section */
 
@@ -126,6 +127,7 @@
 /* Begin PBXFileReference section */
 		00721A8AA4E132139B3B0168 /* Pods-StitchCoreSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDKTests.debug.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDKTests/Pods-StitchCoreSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		13FA6FF839A9BF0FA4286528 /* Pods_StitchCoreSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StitchCoreSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D988771353A1369B3BEF6E2 /* Pods-StitchCoreSDK-StitchCoreSDKMocks.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDK-StitchCoreSDKMocks.debug.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDK-StitchCoreSDKMocks/Pods-StitchCoreSDK-StitchCoreSDKMocks.debug.xcconfig"; sourceTree = "<group>"; };
 		363D0185C367AB395C01ED51 /* Pods_StitchCoreSDKTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StitchCoreSDKTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A340A51C0E9C73E63214D17 /* Pods-StitchCoreSDKMocks.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDKMocks.debug.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDKMocks/Pods-StitchCoreSDKMocks.debug.xcconfig"; sourceTree = "<group>"; };
 		498060EC2185B57C00E2A3A2 /* StitchCoreSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StitchCoreSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -218,9 +220,15 @@
 		4980626B2185B6AF00E2A3A2 /* StitchClientConfigurationUnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StitchClientConfigurationUnitTests.swift; sourceTree = "<group>"; };
 		4980626E2185B6AF00E2A3A2 /* CoreStitchServiceClientUnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreStitchServiceClientUnitTests.swift; sourceTree = "<group>"; };
 		498062F72185C53A00E2A3A2 /* MockUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MockUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5AA2573D2527B617F3E0D280 /* Pods-StitchCoreSDK-StitchCoreSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDK-StitchCoreSDKTests.debug.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDK-StitchCoreSDKTests/Pods-StitchCoreSDK-StitchCoreSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
 		63522D459717B507643396EF /* Pods_StitchCoreSDKMocks.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StitchCoreSDKMocks.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		773EE7BF9450C0A80A5792F2 /* Pods-StitchCoreSDK-StitchCoreSDKMocks.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDK-StitchCoreSDKMocks.release.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDK-StitchCoreSDKMocks/Pods-StitchCoreSDK-StitchCoreSDKMocks.release.xcconfig"; sourceTree = "<group>"; };
 		856072027CC77F81D280BE80 /* Pods-StitchCoreSDK.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDK.debug.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDK/Pods-StitchCoreSDK.debug.xcconfig"; sourceTree = "<group>"; };
+		912E51E221A4B6BC00D50CA6 /* AppMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppMetadata.swift; sourceTree = "<group>"; };
+		BEB96A561F4126EE2EE2EFE5 /* Pods_StitchCoreSDK_StitchCoreSDKTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StitchCoreSDK_StitchCoreSDKTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1B8CC64414DF616AB4B7C9E /* Pods-StitchCoreSDKMocks.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDKMocks.release.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDKMocks/Pods-StitchCoreSDKMocks.release.xcconfig"; sourceTree = "<group>"; };
+		D08FC9A80003C681C99E9ADE /* Pods_StitchCoreSDK_StitchCoreSDKMocks.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StitchCoreSDK_StitchCoreSDKMocks.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D666556FB8429D4295FCEC36 /* Pods-StitchCoreSDK-StitchCoreSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDK-StitchCoreSDKTests.release.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDK-StitchCoreSDKTests/Pods-StitchCoreSDK-StitchCoreSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		DAFA4722A7F7C89C0DBAC954 /* Pods-StitchCoreSDKTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDKTests.release.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDKTests/Pods-StitchCoreSDKTests.release.xcconfig"; sourceTree = "<group>"; };
 		DC1753C4E537221E1CF46A37 /* Pods-StitchCoreSDK.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDK.release.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDK/Pods-StitchCoreSDK.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -526,6 +534,7 @@
 				4980623D2185B6A100E2A3A2 /* Requests */,
 				498062432185B6A100E2A3A2 /* Method.swift */,
 				498062442185B6A100E2A3A2 /* ContentType.swift */,
+				912E51E221A4B6BC00D50CA6 /* AppMetadata.swift */,
 			);
 			path = Net;
 			sourceTree = "<group>";
@@ -720,6 +729,10 @@
 				C1B8CC64414DF616AB4B7C9E /* Pods-StitchCoreSDKMocks.release.xcconfig */,
 				00721A8AA4E132139B3B0168 /* Pods-StitchCoreSDKTests.debug.xcconfig */,
 				DAFA4722A7F7C89C0DBAC954 /* Pods-StitchCoreSDKTests.release.xcconfig */,
+				2D988771353A1369B3BEF6E2 /* Pods-StitchCoreSDK-StitchCoreSDKMocks.debug.xcconfig */,
+				773EE7BF9450C0A80A5792F2 /* Pods-StitchCoreSDK-StitchCoreSDKMocks.release.xcconfig */,
+				5AA2573D2527B617F3E0D280 /* Pods-StitchCoreSDK-StitchCoreSDKTests.debug.xcconfig */,
+				D666556FB8429D4295FCEC36 /* Pods-StitchCoreSDK-StitchCoreSDKTests.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../../Pods;
@@ -732,6 +745,8 @@
 				13FA6FF839A9BF0FA4286528 /* Pods_StitchCoreSDK.framework */,
 				63522D459717B507643396EF /* Pods_StitchCoreSDKMocks.framework */,
 				363D0185C367AB395C01ED51 /* Pods_StitchCoreSDKTests.framework */,
+				D08FC9A80003C681C99E9ADE /* Pods_StitchCoreSDK_StitchCoreSDKMocks.framework */,
+				BEB96A561F4126EE2EE2EFE5 /* Pods_StitchCoreSDK_StitchCoreSDKTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -934,6 +949,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-StitchCoreSDKTests/Pods-StitchCoreSDKTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/MongoSwift/MongoSwift.framework",
+				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/bson.framework",
+				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/bson.framework.dSYM",
+				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/mongoc.framework",
+				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/mongoc.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/JSONWebToken/JWT.framework",
 				"${BUILT_PRODUCTS_DIR}/Swifter/Swifter.framework",
 			);
@@ -941,6 +961,11 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MongoSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/bson.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/bson.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mongoc.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/mongoc.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JWT.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Swifter.framework",
 			);
@@ -1016,6 +1041,7 @@
 				498062A22185B6BC00E2A3A2 /* StitchJWT.swift in Sources */,
 				498062A32185B6BC00E2A3A2 /* CoreStitchUser.swift in Sources */,
 				498062A42185B6BC00E2A3A2 /* AuthInfo.swift in Sources */,
+				912E51E321A4B6BC00D50CA6 /* AppMetadata.swift in Sources */,
 				498062A52185B6BC00E2A3A2 /* CoreStitchAuth+StitchAuthRequestClient.swift in Sources */,
 				498062A62185B6BC00E2A3A2 /* AuthStateHolder.swift in Sources */,
 				498062A72185B6BC00E2A3A2 /* StitchUserIdentity.swift in Sources */,

--- a/Darwin/StitchCore/StitchCore/Core/Internal/StitchAppClientImpl.swift
+++ b/Darwin/StitchCore/StitchCore/Core/Internal/StitchAppClientImpl.swift
@@ -66,9 +66,10 @@ internal final class StitchAppClientImpl: StitchAppClient {
 
         let internalAuth =
             try StitchAuthImpl.init(
-                requestClient: StitchRequestClientImpl.init(baseURL: config.baseURL,
-                                                            transport: config.transport,
-                                                            defaultRequestTimeout: config.defaultRequestTimeout),
+                requestClient: StitchAppRequestClientImpl.init(clientAppId: clientAppID,
+                                                               baseURL: config.baseURL,
+                                                               transport: config.transport,
+                                                               defaultRequestTimeout: config.defaultRequestTimeout),
                 authRoutes: self.routes.authRoutes,
                 storage: config.storage,
                 dispatcher: self.dispatcher,


### PR DESCRIPTION
…r client API calls - unit tests to follow

This follows the pattern established in the Android API by creating a specialized "app client" class that extends the existing functionality in order to retain the application's client app ID for the purpose of looking up the necessary application metadata from the Stitch server in order to know to which hostname to dispatch client API requests.

Tests will follow in a separate PR