### PR TITLE
STITCH-2240 - add toArray, deprecate asArray

### DIFF
--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Internal/CoreRemoteMongoReadOperation.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Internal/CoreRemoteMongoReadOperation.swift
@@ -35,8 +35,13 @@ public class CoreRemoteMongoReadOperation<T: Codable> {
         return try executeRead().first
     }
     
-    public func asArray() throws -> [T] {
+    public func toArray() throws -> [T] {
         return try executeRead()
+    }
+    
+    @available(*, deprecated, message: "use toArray instead")
+    public func asArray() throws -> [T] {
+        return try self.toArray()
     }
     
     private func executeRead() throws -> [T] {

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/CoreRemoteMongoCollectionUnitTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/CoreRemoteMongoCollectionUnitTests.swift
@@ -108,7 +108,7 @@ final class CoreRemoteMongoCollectionUnitTests: XCTestCase {
         )
         
         // without filter or options
-        var resultDocs = try coll.find().asArray()
+        var resultDocs = try coll.find().toArray()
         
         XCTAssertEqual(docs, resultDocs)
         
@@ -133,7 +133,7 @@ final class CoreRemoteMongoCollectionUnitTests: XCTestCase {
         resultDocs = try coll.find(expectedFilter, options: RemoteFindOptions.init(
             projection: expectedProject,
             sort: expectedSort
-        )).asArray()
+        )).toArray()
         
         XCTAssertEqual(docs, resultDocs)
         
@@ -165,7 +165,7 @@ final class CoreRemoteMongoCollectionUnitTests: XCTestCase {
         )
         
         do {
-            _ = try coll.find().asArray()
+            _ = try coll.find().toArray()
             XCTFail("function did not fail where expected")
         } catch {
             // do nothing
@@ -187,7 +187,7 @@ final class CoreRemoteMongoCollectionUnitTests: XCTestCase {
         )
         
         // with empty pipeline
-        var resultDocs = try coll.aggregate([]).asArray()
+        var resultDocs = try coll.aggregate([]).toArray()
         
         XCTAssertEqual(docs, resultDocs)
         
@@ -205,7 +205,7 @@ final class CoreRemoteMongoCollectionUnitTests: XCTestCase {
         XCTAssertEqual(expectedArgs, funcArgsArg[0] as? Document)
         
         // with pipeline
-        resultDocs = try coll.aggregate([["$match": 1], ["sort": 2]]).asArray()
+        resultDocs = try coll.aggregate([["$match": 1], ["sort": 2]]).toArray()
         
         let expectedPipeline: [Document] = [
             ["$match": Int32(1)],
@@ -240,7 +240,7 @@ final class CoreRemoteMongoCollectionUnitTests: XCTestCase {
         )
         
         do {
-            _ = try coll.aggregate([]).asArray()
+            _ = try coll.aggregate([]).toArray()
             XCTFail("function did not fail where expected")
         } catch {
             // do nothing

--- a/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
+++ b/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
@@ -949,11 +949,6 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-StitchCoreSDKTests/Pods-StitchCoreSDKTests-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/MongoSwift/MongoSwift.framework",
-				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/bson.framework",
-				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/bson.framework.dSYM",
-				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/mongoc.framework",
-				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/mongoc.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/JSONWebToken/JWT.framework",
 				"${BUILT_PRODUCTS_DIR}/Swifter/Swifter.framework",
 			);
@@ -961,11 +956,6 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MongoSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/bson.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/bson.framework.dSYM",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mongoc.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/mongoc.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/JWT.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Swifter.framework",
 			);

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoReadOperation.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoReadOperation.swift
@@ -40,10 +40,23 @@ public class RemoteMongoReadOperation<T: Codable> {
      *                        This handler is executed on a non-main global `DispatchQueue`. If the operation is
      *                        successful, the result will contain the documents in the result as an array.
      */
-    public func asArray(_ completionHandler: @escaping (StitchResult<[T]>) -> Void) {
+    public func toArray(_ completionHandler: @escaping (StitchResult<[T]>) -> Void) {
         self.dispatcher.run(withCompletionHandler: completionHandler) {
-            return try self.proxy.asArray()
+            return try self.proxy.toArray()
         }
+    }
+    
+    /**
+     * Executes the operation and returns the result as an array. Deprecated in favor of toArray.
+     *
+     * - parameters:
+     *   - completionHandler: The completion handler to call when the operation is completed or if the operation fails.
+     *                        This handler is executed on a non-main global `DispatchQueue`. If the operation is
+     *                        successful, the result will contain the documents in the result as an array.
+     */
+    @available(*, deprecated, message: "use toArray instead")
+    public func asArray(_ completionHandler: @escaping (StitchResult<[T]>) -> Void) {
+        self.toArray(completionHandler)
     }
     
     /**

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/RemoteMongoClientIntTests.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/RemoteMongoClientIntTests.swift
@@ -198,7 +198,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
     func testFind() {
         let coll = getTestColl()
         var exp = expectation(description: "should not find any documents in empty collection")
-        coll.find().asArray { result in
+        coll.find().toArray { result in
             switch result {
             case .success(let docs):
                 XCTAssertEqual([], docs)
@@ -217,7 +217,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         wait(for: [exp], timeout: 5.0)
         
         exp = expectation(description: "should find the inserted documents")
-        coll.find().asArray { result in
+        coll.find().toArray { result in
             switch result {
             case .success(let resultDocs):
                 XCTAssertEqual(self.withoutId(doc1), self.withoutId(resultDocs[0]))
@@ -327,7 +327,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
     func testAggregate() {
         let coll = getTestColl()
         var exp = expectation(description: "should not find any documents in empty collection")
-        coll.aggregate([]).asArray { result in
+        coll.aggregate([]).toArray { result in
             switch result {
             case .success(let docs):
                 XCTAssertEqual([], docs)
@@ -346,7 +346,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         wait(for: [exp], timeout: 5.0)
         
         exp = expectation(description: "should find the inserted documents")
-        coll.aggregate([]).asArray { result in
+        coll.aggregate([]).toArray { result in
             switch result {
             case .success(let docs):
                 XCTAssertEqual(self.withoutId(doc1), self.withoutId(docs[0]))
@@ -361,7 +361,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         exp = expectation(
             description: "should find the second document when sorting by descending object id, and limiting to 1"
         )
-        coll.aggregate([["$sort": ["_id": -1] as Document], ["$limit": 1]]).asArray { result in
+        coll.aggregate([["$sort": ["_id": -1] as Document], ["$limit": 1]]).toArray { result in
             switch result {
             case .success(let docs):
                 XCTAssertEqual(1, docs.count)
@@ -374,7 +374,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         wait(for: [exp], timeout: 5.0)
         
         exp = expectation(description: "should find first document when matching for it")
-        coll.aggregate([["$match": doc1]]).asArray { result in
+        coll.aggregate([["$match": doc1]]).toArray { result in
             switch result {
             case .success(let docs):
                 XCTAssertEqual(1, docs.count)
@@ -517,7 +517,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         wait(for: [exp], timeout: 5.0)
         
         exp = expectation(description: "all inserted documents should be findable")
-        coll.find().asArray { result in
+        coll.find().toArray { result in
             switch result {
             case .success(let documents):
                 XCTAssertEqual(self.withoutIds([doc1, doc2, doc3, doc4]), self.withoutIds(documents))
@@ -952,7 +952,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         let expectedDoc2: Document = ["woof": "meow"]
         
         exp = expectation(description: "should find the updated documents in the collection")
-        coll.find().asArray { result in
+        coll.find().toArray { result in
             switch result {
             case .success(let documents):
                 XCTAssertEqual([expectedDoc1, expectedDoc2], self.withoutIds(documents))


### PR DESCRIPTION
This ticket soft-deprecates the "asArray" method in the SDK in both the `CoreRemoteMongoReadOperation` and `RemoteMongoReadOperation` classes and adds a corresponding `toArray` method that does the same thing.

This change is intended to alleviate the issue that the Functions JS SDK differs from the other SDKs in this way.

The `asArray` function will stay in place at least until an appropriate time per semantic versioning guidelines (e.g. a major version upgrade).