### PR TITLE
STITCH-2262 Happy path DELETE

### DIFF
--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreDocumentSynchronizationConfig.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreDocumentSynchronizationConfig.swift
@@ -37,7 +37,7 @@ internal struct CoreDocumentSynchronization: Hashable {
         let namespace: MongoNamespace
         let documentId: HashableBSONValue
         fileprivate var uncommittedChangeEvent: ChangeEvent<Document>?
-        fileprivate var lastResolution: UInt64
+        fileprivate var lastResolution: Int64
         fileprivate var lastKnownRemoteVersion: Document?
         fileprivate var isStale: Bool
         fileprivate var isPaused: Bool
@@ -45,7 +45,7 @@ internal struct CoreDocumentSynchronization: Hashable {
         init(namespace: MongoNamespace,
              documentId: HashableBSONValue,
              lastUncommittedChangeEvent: ChangeEvent<Document>?,
-             lastResolution: UInt64,
+             lastResolution: Int64,
              lastKnownRemoteVersion: Document?,
              isStale: Bool,
              isPaused: Bool) {
@@ -96,7 +96,7 @@ internal struct CoreDocumentSynchronization: Hashable {
     }
 
     /// The last time a pending write has been triggered.
-    var lastResolution: UInt64 {
+    var lastResolution: Int64 {
         get {
             docLock.readLock()
             defer { docLock.unlock() }
@@ -212,7 +212,7 @@ internal struct CoreDocumentSynchronization: Hashable {
      - parameter atTime: the time at which the write occurred.
      - parameter changeEvent: the description of the write/change.
      */
-    mutating func setSomePendingWrites(atTime: UInt64,
+    mutating func setSomePendingWrites(atTime: Int64,
                                        changeEvent: ChangeEvent<Document>) throws {
         // if we were frozen
         if (isPaused) {
@@ -241,7 +241,7 @@ internal struct CoreDocumentSynchronization: Hashable {
      - parameter atVersion:   the version for which the write occurred.
      - parameter changeEvent: the description of the write/change.
      */
-    mutating func setSomePendingWrites(atTime: UInt64,
+    mutating func setSomePendingWrites(atTime: Int64,
                                        atVersion: Document,
                                        changeEvent: ChangeEvent<Document>) throws {
         docLock.writeLock()

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreSync.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreSync.swift
@@ -188,8 +188,9 @@ public final class CoreSync<DocumentT: Codable> {
      - parameter filter: the query filter to apply the the delete operation
      - returns: the result of the remove one operation
      */
-    public func deleteOne(filter: Document) -> DeleteResult? {
-        return self.dataSynchronizer.deleteOne(filter: filter,
+    public func deleteOne(filter: Document) throws -> DeleteResult? {
+        return try self.dataSynchronizer.deleteOne(filter: filter,
+                                               options: nil,
                                                in: namespace)
     }
 
@@ -200,8 +201,9 @@ public final class CoreSync<DocumentT: Codable> {
      - parameter filter: the query filter to apply the the delete operation
      - returns: the result of the remove many operation
      */
-    public func deleteMany(filter: Document) -> DeleteResult? {
-        return self.dataSynchronizer.deleteMany(filter: filter,
+    public func deleteMany(filter: Document) throws -> DeleteResult? {
+        return try self.dataSynchronizer.deleteMany(filter: filter,
+                                                options: nil,
                                                 in: namespace)
     }
 

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/DataSynchronizer.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/DataSynchronizer.swift
@@ -575,7 +575,6 @@ public class DataSynchronizer: NetworkStateDelegate, FatalErrorListener {
 
         let result = try localColl.deleteMany(filter, options: options)
 
-        typealias EventTuple = (BSONValue, ChangeEvent<Document>)
         let eventEmitters = try idsToDelete.compactMap { documentId -> (() -> Void)? in
             guard var docConfig = nsConfig[documentId] else {
                 return nil

--- a/Core/Services/StitchCoreRemoteMongoDBService/StitchCoreRemoteMongoDBService.xcodeproj/project.pbxproj
+++ b/Core/Services/StitchCoreRemoteMongoDBService/StitchCoreRemoteMongoDBService.xcodeproj/project.pbxproj
@@ -129,8 +129,8 @@
 		OBJ_27 /* CoreRemoteMongoCollectionUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreRemoteMongoCollectionUnitTests.swift; sourceTree = "<group>"; };
 		OBJ_28 /* CoreRemoteMongoDatabaseUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreRemoteMongoDatabaseUnitTests.swift; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		"StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService::Product" /* StitchCoreRemoteMongoDBService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreRemoteMongoDBService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests::Product" /* StitchCoreRemoteMongoDBServiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = StitchCoreRemoteMongoDBServiceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService::Product /* StitchCoreRemoteMongoDBService.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StitchCoreRemoteMongoDBService.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests::Product /* StitchCoreRemoteMongoDBServiceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = StitchCoreRemoteMongoDBServiceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -261,8 +261,8 @@
 		OBJ_141 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				"StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests::Product" /* StitchCoreRemoteMongoDBServiceTests.xctest */,
-				"StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService::Product" /* StitchCoreRemoteMongoDBService.framework */,
+				StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests::Product /* StitchCoreRemoteMongoDBServiceTests.xctest */,
+				StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService::Product /* StitchCoreRemoteMongoDBService.framework */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -310,7 +310,7 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		"StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService" /* StitchCoreRemoteMongoDBService */ = {
+		StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService /* StitchCoreRemoteMongoDBService */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_164 /* Build configuration list for PBXNativeTarget "StitchCoreRemoteMongoDBService" */;
 			buildPhases = (
@@ -324,10 +324,10 @@
 			);
 			name = StitchCoreRemoteMongoDBService;
 			productName = StitchCoreRemoteMongoDBService;
-			productReference = "StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService::Product" /* StitchCoreRemoteMongoDBService.framework */;
+			productReference = StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService::Product /* StitchCoreRemoteMongoDBService.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		"StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests" /* StitchCoreRemoteMongoDBServiceTests */ = {
+		StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests /* StitchCoreRemoteMongoDBServiceTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = OBJ_196 /* Build configuration list for PBXNativeTarget "StitchCoreRemoteMongoDBServiceTests" */;
 			buildPhases = (
@@ -343,7 +343,7 @@
 			);
 			name = StitchCoreRemoteMongoDBServiceTests;
 			productName = StitchCoreRemoteMongoDBServiceTests;
-			productReference = "StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests::Product" /* StitchCoreRemoteMongoDBServiceTests.xctest */;
+			productReference = StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests::Product /* StitchCoreRemoteMongoDBServiceTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -366,8 +366,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				"StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService" /* StitchCoreRemoteMongoDBService */,
-				"StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests" /* StitchCoreRemoteMongoDBServiceTests */,
+				StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService /* StitchCoreRemoteMongoDBService */,
+				StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBServiceTests /* StitchCoreRemoteMongoDBServiceTests */,
 			);
 		};
 /* End PBXProject section */
@@ -433,6 +433,7 @@
 				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/mongoc.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/MongoMobile/MongoMobile.framework",
 				"${PODS_ROOT}/mongo_embedded/iPhoneOS/Frameworks/mongo_embedded.framework",
+				"${PODS_ROOT}/mongo_embedded/iPhoneOS/Frameworks/mongo_embedded.framework.dSYM",
 				"${PODS_ROOT}/mongoc_embedded/iPhoneOS/Frameworks/mongoc_embedded.framework",
 				"${PODS_ROOT}/mongoc_embedded/iPhoneOS/Frameworks/mongoc_embedded.framework.dSYM",
 			);
@@ -447,6 +448,7 @@
 				"${DWARF_DSYM_FOLDER_PATH}/mongoc.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MongoMobile.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mongo_embedded.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/mongo_embedded.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mongoc_embedded.framework",
 				"${DWARF_DSYM_FOLDER_PATH}/mongoc_embedded.framework.dSYM",
 			);
@@ -521,7 +523,7 @@
 /* Begin PBXTargetDependency section */
 		OBJ_212 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService" /* StitchCoreRemoteMongoDBService */;
+			target = StitchCoreRemoteMongoDBService::StitchCoreRemoteMongoDBService /* StitchCoreRemoteMongoDBService */;
 			targetProxy = 498060582184CF4300E2A3A2 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/CoreDocumentSynchronizationConfigTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/CoreDocumentSynchronizationConfigTests.swift
@@ -27,7 +27,8 @@ class CoreDocumentSynchronizationConfigTests: XCMongoMobileTestCase {
         let isPaused = true
         let isStale = true
         let lastKnownRemoteVersion = DocumentVersionInfo.freshVersionDocument()
-        let lastResolution: UInt32 = 42
+
+        let lastResolution: Int64 = 42
 
         let ceId = ["_id": documentId] as Document
         let ceFullDocument = ["foo": "bar"] as Document
@@ -59,8 +60,8 @@ class CoreDocumentSynchronizationConfigTests: XCMongoMobileTestCase {
                        encodedCoreDocSync[CoreDocumentSynchronization.Config.CodingKeys.isStale.rawValue] as? Bool)
         XCTAssertEqual(lastKnownRemoteVersion,
                        encodedCoreDocSync[CoreDocumentSynchronization.Config.CodingKeys.lastKnownRemoteVersion.rawValue] as? Document)
-        XCTAssertEqual(Int(lastResolution),
-                       encodedCoreDocSync[CoreDocumentSynchronization.Config.CodingKeys.lastResolution.rawValue] as? Int)
+        XCTAssertEqual(lastResolution,
+                       encodedCoreDocSync[CoreDocumentSynchronization.Config.CodingKeys.lastResolution.rawValue] as? Int64)
         XCTAssertEqual(lastUncommittedChangeEvent,
                        try BSONDecoder().decode(ChangeEvent.self,
                                                 from: encodedCoreDocSync[CoreDocumentSynchronization.Config.CodingKeys.uncommittedChangeEvent.rawValue] as! Document))

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/DataSynchronizerIntTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/DataSynchronizerIntTests.swift
@@ -53,35 +53,4 @@ class DataSynchronizerUnitTests: XCMongoMobileTestCase {
 
         XCTAssertFalse(dataSynchronizer.isRunning)
     }
-
-    // TODO: STITCH-2215: This is an integration test and
-    // should be moved upstream to `Sync` within RemoteMongoClientIntTests.
-    // This will be possible after configuration is configured.
-    func testDeleteMany() throws {
-        dataSynchronizer.configure(namespace: namespace,
-                                   conflictHandler: TestConflictHandler(),
-                                   changeEventListener: TestEventListener(),
-                                   errorListener: TestErrorListener())
-        XCTAssertEqual(0, try dataSynchronizer.count(in: namespace))
-
-
-        let doc1 = ["hello": "world", "a": "b"] as Document
-        let doc2 = ["goodbye": "world", "a": "b"] as Document
-
-        _ = try dataSynchronizer.insertMany(documents: [doc1, doc2],
-                                            in: namespace)
-
-        XCTAssertEqual(2, try dataSynchronizer.count(in: namespace))
-
-        var deleteResult = try dataSynchronizer.deleteMany(filter: ["a": "c"], options: nil, in: namespace)
-        XCTAssertEqual(0, deleteResult?.deletedCount)
-
-        XCTAssertEqual(2, try dataSynchronizer.count(in: namespace))
-
-
-        deleteResult = try dataSynchronizer.deleteMany(filter: ["a": "b"], options: nil, in: namespace)
-        XCTAssertEqual(2, deleteResult?.deletedCount)
-
-        XCTAssertEqual(0, try dataSynchronizer.count(in: namespace))
-    }
 }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/DataSynchronizerIntTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/DataSynchronizerIntTests.swift
@@ -53,4 +53,68 @@ class DataSynchronizerUnitTests: XCMongoMobileTestCase {
 
         XCTAssertFalse(dataSynchronizer.isRunning)
     }
+
+    // TODO: STITCH-2215: This is an integration test and
+    // should be moved upstream to `Sync` within RemoteMongoClientIntTests.
+    // This will be possible after configuration is configured.
+    func testDeleteOne() throws {
+        dataSynchronizer.configure(namespace: namespace,
+                                   conflictHandler: TestConflictHandler(),
+                                   changeEventListener: TestEventListener(),
+                                   errorListener: TestErrorListener())
+        XCTAssertEqual(0, try dataSynchronizer.count(in: namespace))
+
+
+        let doc1 = ["hello": "world", "a": "b"] as Document
+        let doc2 = ["goodbye": "world", "a": "b"] as Document
+
+        _ = try dataSynchronizer.insertMany(documents: [doc1, doc2],
+                                            in: namespace)
+
+        XCTAssertEqual(2, try dataSynchronizer.count(in: namespace))
+
+        var deleteResult = try dataSynchronizer.deleteOne(filter: ["hello": "world"], options: nil, in: namespace)
+        XCTAssertEqual(1, deleteResult?.deletedCount)
+
+        XCTAssertEqual(1, try dataSynchronizer.count(in: namespace))
+        XCTAssertEqual(0, try dataSynchronizer.count(filter: ["hello": "world"], options: nil, in: namespace))
+
+        deleteResult = try dataSynchronizer.deleteOne(filter: [], options: nil, in: namespace)
+        XCTAssertEqual(1, deleteResult?.deletedCount)
+        XCTAssertEqual(0, try dataSynchronizer.count(in: namespace))
+
+        deleteResult = try dataSynchronizer.deleteOne(filter: [], options: nil, in: namespace)
+        XCTAssertEqual(0, deleteResult?.deletedCount)
+    }
+
+    // TODO: STITCH-2215: This is an integration test and
+    // should be moved upstream to `Sync` within RemoteMongoClientIntTests.
+    // This will be possible after configuration is configured.
+    func testDeleteMany() throws {
+        dataSynchronizer.configure(namespace: namespace,
+                                   conflictHandler: TestConflictHandler(),
+                                   changeEventListener: TestEventListener(),
+                                   errorListener: TestErrorListener())
+        XCTAssertEqual(0, try dataSynchronizer.count(in: namespace))
+
+
+        let doc1 = ["hello": "world", "a": "b"] as Document
+        let doc2 = ["goodbye": "world", "a": "b"] as Document
+
+        _ = try dataSynchronizer.insertMany(documents: [doc1, doc2],
+                                            in: namespace)
+
+        XCTAssertEqual(2, try dataSynchronizer.count(in: namespace))
+
+        var deleteResult = try dataSynchronizer.deleteMany(filter: ["a": "c"], options: nil, in: namespace)
+        XCTAssertEqual(0, deleteResult?.deletedCount)
+
+        XCTAssertEqual(2, try dataSynchronizer.count(in: namespace))
+
+
+        deleteResult = try dataSynchronizer.deleteMany(filter: ["a": "b"], options: nil, in: namespace)
+        XCTAssertEqual(2, deleteResult?.deletedCount)
+
+        XCTAssertEqual(0, try dataSynchronizer.count(in: namespace))
+    }
 }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/DataSynchronizerIntTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/DataSynchronizerIntTests.swift
@@ -57,39 +57,6 @@ class DataSynchronizerUnitTests: XCMongoMobileTestCase {
     // TODO: STITCH-2215: This is an integration test and
     // should be moved upstream to `Sync` within RemoteMongoClientIntTests.
     // This will be possible after configuration is configured.
-    func testDeleteOne() throws {
-        dataSynchronizer.configure(namespace: namespace,
-                                   conflictHandler: TestConflictHandler(),
-                                   changeEventListener: TestEventListener(),
-                                   errorListener: TestErrorListener())
-        XCTAssertEqual(0, try dataSynchronizer.count(in: namespace))
-
-
-        let doc1 = ["hello": "world", "a": "b"] as Document
-        let doc2 = ["goodbye": "world", "a": "b"] as Document
-
-        _ = try dataSynchronizer.insertMany(documents: [doc1, doc2],
-                                            in: namespace)
-
-        XCTAssertEqual(2, try dataSynchronizer.count(in: namespace))
-
-        var deleteResult = try dataSynchronizer.deleteOne(filter: ["hello": "world"], options: nil, in: namespace)
-        XCTAssertEqual(1, deleteResult?.deletedCount)
-
-        XCTAssertEqual(1, try dataSynchronizer.count(in: namespace))
-        XCTAssertEqual(0, try dataSynchronizer.count(filter: ["hello": "world"], options: nil, in: namespace))
-
-        deleteResult = try dataSynchronizer.deleteOne(filter: [], options: nil, in: namespace)
-        XCTAssertEqual(1, deleteResult?.deletedCount)
-        XCTAssertEqual(0, try dataSynchronizer.count(in: namespace))
-
-        deleteResult = try dataSynchronizer.deleteOne(filter: [], options: nil, in: namespace)
-        XCTAssertEqual(0, deleteResult?.deletedCount)
-    }
-
-    // TODO: STITCH-2215: This is an integration test and
-    // should be moved upstream to `Sync` within RemoteMongoClientIntTests.
-    // This will be possible after configuration is configured.
     func testDeleteMany() throws {
         dataSynchronizer.configure(namespace: namespace,
                                    conflictHandler: TestConflictHandler(),

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService.xcodeproj/project.pbxproj
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService.xcodeproj/project.pbxproj
@@ -348,6 +348,7 @@
 				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/mongoc.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/MongoMobile/MongoMobile.framework",
 				"${PODS_ROOT}/mongo_embedded/iPhoneOS/Frameworks/mongo_embedded.framework",
+				"${PODS_ROOT}/mongo_embedded/iPhoneOS/Frameworks/mongo_embedded.framework.dSYM",
 				"${PODS_ROOT}/mongoc_embedded/iPhoneOS/Frameworks/mongoc_embedded.framework",
 				"${PODS_ROOT}/mongoc_embedded/iPhoneOS/Frameworks/mongoc_embedded.framework.dSYM",
 			);
@@ -362,6 +363,7 @@
 				"${DWARF_DSYM_FOLDER_PATH}/mongoc.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MongoMobile.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mongo_embedded.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/mongo_embedded.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mongoc_embedded.framework",
 				"${DWARF_DSYM_FOLDER_PATH}/mongoc_embedded.framework.dSYM",
 			);

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
@@ -245,8 +245,15 @@ public class Sync<DocumentT: Codable> {
      - parameter filter: the query filter to apply the the delete operation
      - returns: the result of the remove one operation
      */
-    func deleteOne(filter: Document) -> DeleteResult? {
-        return self.proxy.deleteOne(filter: filter)
+    func deleteOne(filter: Document,
+                   _ completionHandler: @escaping (StitchResult<DeleteResult?>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(.success(result: try self.proxy.deleteOne(filter: filter)))
+            } catch {
+                completionHandler(.failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
+            }
+        }
     }
 
     /**
@@ -256,8 +263,15 @@ public class Sync<DocumentT: Codable> {
      - parameter filter: the query filter to apply the the delete operation
      - returns: the result of the remove many operation
      */
-    func deleteMany(filter: Document) -> DeleteResult? {
-        return self.proxy.deleteMany(filter: filter)
+    func deleteMany(filter: Document,
+                    _ completionHandler: @escaping (StitchResult<DeleteResult?>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(.success(result: try self.proxy.deleteMany(filter: filter)))
+            } catch {
+                completionHandler(.failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
+            }
+        }
     }
 
     /**

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/RemoteMongoClientIntTests.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/RemoteMongoClientIntTests.swift
@@ -1049,7 +1049,11 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         sync.count(joiner.capture())
 
         XCTAssertEqual(2, joiner.value())
-        // TODO: STITCH-2262 Add delete case
+
+        sync.deleteMany(filter: ["a": "b"], joiner.capture())
+        sync.count(joiner.capture())
+
+        XCTAssertEqual(0, joiner.value())
     }
 
     func testSync_Find() throws {
@@ -1306,6 +1310,103 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
             XCTAssertEqual("goodbye", actualDoc["hello"] as? String)
             XCTAssertFalse(actualDoc.hasKey(DOCUMENT_VERSION_FIELD))
         }
+    }
+
+    func testSync_deleteOne() throws {
+        let coll = getTestColl()
+        let sync = coll.sync
+
+        sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
+                       changeEventDelegate: { _, _ in },
+                       errorListener: { _, _ in })
+
+        let joiner = CallbackJoiner()
+
+        // ensure that the test collection is empty
+        sync.count(joiner.capture())
+        XCTAssertEqual(0, joiner.value())
+
+        // insert some test documents
+        let doc1 = ["hello": "world", "a": "b"] as Document
+        let doc2 = ["goodbye": "world", "a": "b"] as Document
+        sync.insertMany(documents: [doc1, doc2], joiner.capture())
+
+        // ensure that the documents were inserted
+        sync.count(joiner.capture())
+        XCTAssertEqual(2, joiner.value())
+
+        // delete the { hello: "world" } document
+        sync.deleteOne(filter: ["hello": "world"], joiner.capture())
+        var deleteResult = joiner.value(asType: DeleteResult.self)
+        XCTAssertEqual(1, deleteResult?.deletedCount)
+
+        // ensure that there is only one document, and that it is the { goodbye: "world" } one
+        sync.count(joiner.capture())
+        XCTAssertEqual(1, joiner.value())
+
+        sync.count(filter: ["hello": "world"], options: nil, joiner.capture())
+        XCTAssertEqual(0, joiner.value())
+
+        // delete the remaining document with empty filter
+        sync.deleteOne(filter: [], joiner.capture())
+        deleteResult = joiner.value(asType: DeleteResult.self)
+        XCTAssertEqual(1, deleteResult?.deletedCount)
+
+        // collection should be empty
+        sync.count(joiner.capture())
+        XCTAssertEqual(0, joiner.value())
+
+        // should not be able to delete any more documents
+        sync.deleteOne(filter: [], joiner.capture())
+        deleteResult = joiner.value(asType: DeleteResult.self)
+        XCTAssertEqual(0, deleteResult?.deletedCount)
+    }
+
+    func testSync_deleteMany() throws {
+        let coll = getTestColl()
+        let sync = coll.sync
+
+        sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
+                       changeEventDelegate: { _, _ in },
+                       errorListener: { _, _ in })
+
+        let joiner = CallbackJoiner()
+
+        // ensure that the test collection is empty
+        sync.count(joiner.capture())
+        XCTAssertEqual(0, joiner.value())
+
+        // insert some test documents
+        let doc1 = ["hello": "world", "a": "b"] as Document
+        let doc2 = ["goodbye": "world", "a": "b"] as Document
+        sync.insertMany(documents: [doc1, doc2], joiner.capture())
+
+        // ensure that the documents were inserted
+        sync.count(joiner.capture())
+        XCTAssertEqual(2, joiner.value())
+
+        // delete documents with a filter for which there are no documents
+        sync.deleteMany(filter: ["a": "c"], joiner.capture())
+        var deleteResult = joiner.value(asType: DeleteResult.self)
+        XCTAssertEqual(0, deleteResult?.deletedCount)
+
+        // ensure nothing got deleted
+        sync.count(joiner.capture())
+        XCTAssertEqual(2, joiner.value())
+
+        // delete all the documents we inserted
+        sync.deleteOne(filter: ["a": "b"], joiner.capture())
+        deleteResult = joiner.value(asType: DeleteResult.self)
+        XCTAssertEqual(2, deleteResult?.deletedCount)
+
+        // collection should be empty
+        sync.count(joiner.capture())
+        XCTAssertEqual(0, joiner.value())
+
+        // should not be able to delete any more documents
+        sync.deleteMany(filter: [], joiner.capture())
+        deleteResult = joiner.value(asType: DeleteResult.self)
+        XCTAssertEqual(0, deleteResult?.deletedCount)
     }
 }
 

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/RemoteMongoClientIntTests.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/RemoteMongoClientIntTests.swift
@@ -1395,7 +1395,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         XCTAssertEqual(2, joiner.value())
 
         // delete all the documents we inserted
-        sync.deleteOne(filter: ["a": "b"], joiner.capture())
+        sync.deleteMany(filter: ["a": "b"], joiner.capture())
         deleteResult = joiner.value(asType: DeleteResult.self)
         XCTAssertEqual(2, deleteResult?.deletedCount)
 


### PR DESCRIPTION
These are the implementation and tests for happy path delete. Also drove-by a fix to make the logicalT and lastResolution fields be `Int64` so they are properly encoded. This is not quite ready to be merged, since I believe I will need to add a few more tests once Jason merges STITCH-2215