### PR TITLE
STITCH-2312 Store uncommitted change events as BSON Binary

### DIFF
--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreDocumentSynchronizationConfig.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreDocumentSynchronizationConfig.swift
@@ -30,8 +30,12 @@ internal class CoreDocumentSynchronization: Hashable {
     /// The actual configuration to be persisted for this document.
     class Config: Codable, Hashable {
         enum CodingKeys: String, CodingKey {
-            case namespace, documentId, uncommittedChangeEvent,
-            lastResolution, lastKnownRemoteVersion, isStale, isPaused
+            // These are snake_case because we are trying to keep the internal
+            // representation consistent across platforms
+            case namespace = "namespace",
+            documentId = "document_id", uncommittedChangeEvent = "last_uncommitted_change_event",
+            lastResolution = "last_resolution", lastKnownRemoteVersion = "last_known_remote_version",
+            isStale = "is_stale", isPaused = "is_paused", schemaVersion = "schema_version"
         }
 
         let namespace: MongoNamespace
@@ -42,7 +46,68 @@ internal class CoreDocumentSynchronization: Hashable {
         fileprivate var isStale: Bool
         fileprivate var isPaused: Bool
 
-        init(namespace: MongoNamespace,
+        // from BSON document
+        required init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: CodingKeys.self)
+
+            // verify schema version
+            let schemaVersion = try values.decode(Int32.self, forKey: .schemaVersion)
+            if schemaVersion != 1 {
+                throw DataSynchronizerError(
+                    "unexpected schema version \(schemaVersion) for CoreDocumentSynchronization.Config"
+                )
+            }
+
+            self.namespace = try values.decode(MongoNamespace.self, forKey: .namespace)
+
+            if values.contains(.lastKnownRemoteVersion) {
+                self.lastKnownRemoteVersion = try values.decode(Document.self, forKey: .lastKnownRemoteVersion)
+            }
+
+            if values.contains(.uncommittedChangeEvent) {
+                let eventBin = try values.decode(Binary.self, forKey: .uncommittedChangeEvent)
+                let eventDocument = Document.init(fromBSON: eventBin.data)
+
+                self.uncommittedChangeEvent =
+                    try BSONDecoder().decode(ChangeEvent.self, from: eventDocument)
+            }
+
+            self.documentId = HashableBSONValue.init(try values.decode(AnyBSONValue.self, forKey: .documentId))
+            self.lastResolution = try values.decode(Int64.self, forKey: .lastResolution)
+            self.isStale = try values.decode(Bool.self, forKey: .isStale)
+            self.isPaused = try values.decode(Bool.self, forKey: .isPaused)
+        }
+
+        // to BSON document
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(documentId.bsonValue, forKey: .documentId)
+
+            // verify schema version
+            try container.encode(1 as Int32, forKey: .schemaVersion)
+
+            try container.encode(namespace, forKey: .namespace)
+            try container.encode(lastResolution, forKey: .lastResolution)
+
+            if let lastKnownRemoteVersion = lastKnownRemoteVersion {
+                try container.encode(lastKnownRemoteVersion, forKey: .lastKnownRemoteVersion)
+            }
+
+            if let uncommittedChangeEvent = uncommittedChangeEvent {
+                let changeEventDoc = try BSONEncoder().encode(uncommittedChangeEvent)
+                // TODO: This may put the doc above the 16MiB but ignore for now.
+                try container.encode(
+                    Binary.init(data: changeEventDoc.rawBSON, subtype: Binary.Subtype.generic),
+                    forKey: .uncommittedChangeEvent
+                )
+            }
+
+            try container.encode(isStale, forKey: .isStale)
+            try container.encode(isPaused, forKey: .isPaused)
+        }
+
+        required init(namespace: MongoNamespace,
              documentId: HashableBSONValue,
              lastUncommittedChangeEvent: ChangeEvent<Document>?,
              lastResolution: Int64,
@@ -66,6 +131,8 @@ internal class CoreDocumentSynchronization: Hashable {
         func hash(into hasher: inout Hasher) {
             documentId.hash(into: &hasher)
         }
+
+
     }
 
     /// The collection we are storing document configs in.

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreDocumentSynchronizationConfig.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/CoreDocumentSynchronizationConfig.swift
@@ -60,19 +60,19 @@ internal class CoreDocumentSynchronization: Hashable {
 
             self.namespace = try values.decode(MongoNamespace.self, forKey: .namespace)
 
-            if values.contains(.lastKnownRemoteVersion) {
-                self.lastKnownRemoteVersion = try values.decode(Document.self, forKey: .lastKnownRemoteVersion)
+            if let lastKnownRemoteVersion =
+                try values.decodeIfPresent(Document.self, forKey: .lastKnownRemoteVersion) {
+                self.lastKnownRemoteVersion = lastKnownRemoteVersion
             }
 
-            if values.contains(.uncommittedChangeEvent) {
-                let eventBin = try values.decode(Binary.self, forKey: .uncommittedChangeEvent)
+            if let eventBin = try values.decodeIfPresent(Binary.self, forKey: .uncommittedChangeEvent) {
                 let eventDocument = Document.init(fromBSON: eventBin.data)
 
                 self.uncommittedChangeEvent =
                     try BSONDecoder().decode(ChangeEvent.self, from: eventDocument)
             }
 
-            self.documentId = HashableBSONValue.init(try values.decode(AnyBSONValue.self, forKey: .documentId))
+            self.documentId = try values.decode(HashableBSONValue.self, forKey: .documentId)
             self.lastResolution = try values.decode(Int64.self, forKey: .lastResolution)
             self.isStale = try values.decode(Bool.self, forKey: .isStale)
             self.isPaused = try values.decode(Bool.self, forKey: .isPaused)
@@ -82,7 +82,7 @@ internal class CoreDocumentSynchronization: Hashable {
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
 
-            try container.encode(documentId.bsonValue, forKey: .documentId)
+            try container.encode(documentId, forKey: .documentId)
 
             // verify schema version
             try container.encode(1 as Int32, forKey: .schemaVersion)

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ThreadSafeMongoMobile.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/ThreadSafeMongoMobile.swift
@@ -63,6 +63,10 @@ class ThreadSafeMongoCollection<T: Codable> {
             .collection(name, withType: T.self)
     }
 
+    func drop() throws {
+        try underlyingCollection().drop()
+    }
+
     func aggregate(_ pipeline: [Document], options: AggregateOptions? = nil) throws -> MongoCursor<Document> {
         return try underlyingCollection().aggregate(pipeline, options: options)
     }

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/CoreDocumentSynchronizationConfigTests.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/CoreDocumentSynchronizationConfigTests.swift
@@ -60,9 +60,14 @@ class CoreDocumentSynchronizationConfigTests: XCMongoMobileTestCase {
                        encodedCoreDocSync[CoreDocumentSynchronization.Config.CodingKeys.lastKnownRemoteVersion.rawValue] as? Document)
         XCTAssertEqual(lastResolution,
                        encodedCoreDocSync[CoreDocumentSynchronization.Config.CodingKeys.lastResolution.rawValue] as? Int64)
+
+        let lastUncommittedChangeEventBin =
+                       encodedCoreDocSync[CoreDocumentSynchronization.Config.CodingKeys.uncommittedChangeEvent.rawValue] as? Binary
+        let lastUncommittedChangeEventDoc = Document.init(fromBSON: lastUncommittedChangeEventBin!.data)
+
         XCTAssertEqual(lastUncommittedChangeEvent,
                        try BSONDecoder().decode(ChangeEvent.self,
-                                                from: encodedCoreDocSync[CoreDocumentSynchronization.Config.CodingKeys.uncommittedChangeEvent.rawValue] as! Document))
+                                                from: lastUncommittedChangeEventDoc))
 
         var decodedCoreDocConfig = try BSONDecoder().decode(CoreDocumentSynchronization.Config.self,
                                                             from: encodedCoreDocSync)

--- a/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/XCMongoMobileTestCase.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Tests/StitchCoreRemoteMongoDBServiceTests/Sync/XCMongoMobileTestCase.swift
@@ -290,7 +290,7 @@ class XCMongoMobileTestCase: XCTestCase {
     }
 
     func localCollection() -> ThreadSafeMongoCollection<Document> {
-        return try localCollection(for: MongoNamespace.init(
+        return localCollection(for: MongoNamespace.init(
             databaseName: DataSynchronizer.localUserDBName(withInstanceKey: instanceKey.oid, for: namespace),
             collectionName: namespace.collectionName
         ))

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
@@ -52,7 +52,7 @@ public class Sync<DocumentT: Codable> {
      Requests that the given document _ids be synchronized.
      - parameter ids: the document _ids to synchronize.
      */
-    public func sync(ids: [BSONValue]) {
+    public func sync(ids: [BSONValue]) throws {
         try self.proxy.sync(ids: ids)
     }
 

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
@@ -19,7 +19,7 @@ public class Sync<DocumentT: Codable> {
      document.
      - parameter errorListener: the error listener to invoke when an irrecoverable error occurs
      */
-    func configure(
+    public func configure(
         conflictHandler: @escaping (
         _ documentId: BSONValue,
         _ localEvent: ChangeEvent<DocumentT>,
@@ -39,7 +39,7 @@ public class Sync<DocumentT: Codable> {
      document.
      - parameter errorListener: the error listener to invoke when an irrecoverable error occurs
      */
-    func configure<CH: ConflictHandler, CED: ChangeEventDelegate>(
+    public func configure<CH: ConflictHandler, CED: ChangeEventDelegate>(
         conflictHandler: CH,
         changeEventDelegate: CED? = nil,
         errorListener: ErrorListener? = nil) where CH.DocumentT == DocumentT, CED.DocumentT == DocumentT {
@@ -52,7 +52,7 @@ public class Sync<DocumentT: Codable> {
      Requests that the given document _ids be synchronized.
      - parameter ids: the document _ids to synchronize.
      */
-    func sync(ids: [BSONValue]) throws {
+    public func sync(ids: [BSONValue]) {
         try self.proxy.sync(ids: ids)
     }
 
@@ -60,7 +60,7 @@ public class Sync<DocumentT: Codable> {
      Stops synchronizing the given document _ids. Any uncommitted writes will be lost.
      - parameter ids: the _ids of the documents to desynchronize.
      */
-    func desync(ids: [BSONValue]) throws {
+    public func desync(ids: [BSONValue]) throws {
         try self.proxy.desync(ids: ids)
     }
 
@@ -69,7 +69,7 @@ public class Sync<DocumentT: Codable> {
      TODO Remove custom HashableBSONValue after: https://jira.mongodb.org/browse/SWIFT-255
      - returns: the set of synchronized document ids in a namespace.
      */
-    var syncedIds: Set<HashableBSONValue> {
+    public var syncedIds: Set<HashableBSONValue> {
         return self.proxy.syncedIds
     }
 
@@ -79,7 +79,7 @@ public class Sync<DocumentT: Codable> {
 
      - returns: the set of paused document _ids in a namespace
      */
-    var pausedIds: Set<HashableBSONValue> {
+    public var pausedIds: Set<HashableBSONValue> {
         return self.proxy.pausedIds
     }
 
@@ -92,7 +92,7 @@ public class Sync<DocumentT: Codable> {
      - returns: true if successfully resumed, false if the document
      could not be found or there was an error resuming
      */
-    func resumeSync(forDocumentId documentId: BSONValue) -> Bool {
+    public func resumeSync(forDocumentId documentId: BSONValue) -> Bool {
         return self.proxy.resumeSync(forDocumentId: documentId)
     }
 
@@ -101,7 +101,7 @@ public class Sync<DocumentT: Codable> {
 
      - returns: the number of documents in the collection
      */
-    func count(_ completionHandler: @escaping (StitchResult<Int>) -> Void) {
+    public func count(_ completionHandler: @escaping (StitchResult<Int>) -> Void) {
         queue.async {
             do {
                 completionHandler(
@@ -122,7 +122,7 @@ public class Sync<DocumentT: Codable> {
      - parameter completionHandler: the callback for the count result
      - returns: the number of documents in the collection
      */
-    func count(filter: Document,
+    public func count(filter: Document,
                options: CountOptions?,
                _ completionHandler: @escaping (StitchResult<Int>) -> Void) {
         queue.async {
@@ -143,7 +143,7 @@ public class Sync<DocumentT: Codable> {
      - parameter completionHandler: the callback for the find result
      - returns: the find iterable interface
      */
-    func find(_ completionHandler: @escaping (StitchResult<MongoCursor<DocumentT>>) -> Void) {
+    public func find(_ completionHandler: @escaping (StitchResult<MongoCursor<DocumentT>>) -> Void) {
         queue.async {
             do {
                 completionHandler(
@@ -163,7 +163,7 @@ public class Sync<DocumentT: Codable> {
      - parameter completionHandler: the callback for the find result
      - returns: the find iterable interface
      */
-    func find(
+    public func find(
         filter: Document,
         options: FindOptions? = nil,
         _ completionHandler: @escaping (StitchResult<MongoCursor<DocumentT>>) -> Void) {
@@ -186,7 +186,7 @@ public class Sync<DocumentT: Codable> {
      - parameter options: the options for this aggregate op
      - returns: an iterable containing the result of the aggregation operation
      */
-    func aggregate(pipeline: [Document],
+    public func aggregate(pipeline: [Document],
                    options: AggregateOptions?,
                    _ completionHandler: @escaping (StitchResult<MongoCursor<Document>>) -> Void) {
         queue.async {
@@ -209,7 +209,7 @@ public class Sync<DocumentT: Codable> {
      - parameter document: the document to insert
      - returns: the result of the insert one operation
      */
-    func insertOne(document: DocumentT,
+    public func insertOne(document: DocumentT,
                    _ completionHandler: @escaping (StitchResult<InsertOneResult?>) -> Void) {
         queue.async {
             do {
@@ -226,7 +226,7 @@ public class Sync<DocumentT: Codable> {
      - parameter documents: the documents to insert
      - returns: the result of the insert many operation
      */
-    func insertMany(documents: [DocumentT],
+    public func insertMany(documents: [DocumentT],
                     _ completionHandler: @escaping (StitchResult<InsertManyResult?>) -> Void) {
         queue.async {
             do {
@@ -245,7 +245,7 @@ public class Sync<DocumentT: Codable> {
      - parameter filter: the query filter to apply the the delete operation
      - returns: the result of the remove one operation
      */
-    func deleteOne(filter: Document,
+    public func deleteOne(filter: Document,
                    _ completionHandler: @escaping (StitchResult<DeleteResult?>) -> Void) {
         queue.async {
             do {
@@ -263,7 +263,7 @@ public class Sync<DocumentT: Codable> {
      - parameter filter: the query filter to apply the the delete operation
      - returns: the result of the remove many operation
      */
-    func deleteMany(filter: Document,
+    public func deleteMany(filter: Document,
                     _ completionHandler: @escaping (StitchResult<DeleteResult?>) -> Void) {
         queue.async {
             do {
@@ -284,7 +284,7 @@ public class Sync<DocumentT: Codable> {
      apply must include only update operators.
      - returns: the result of the update one operation
      */
-    func updateOne(filter: Document,
+    public func updateOne(filter: Document,
                    update: Document,
                    options: UpdateOptions?,
                    _ completionHandler: @escaping (StitchResult<UpdateResult?>) -> Void) {
@@ -311,7 +311,7 @@ public class Sync<DocumentT: Codable> {
      - parameter updateOptions: the options to apply to the update operation
      - returns: the result of the update many operation
      */
-    func updateMany(filter: Document,
+    public func updateMany(filter: Document,
                     update: Document,
                     options: UpdateOptions?,
                     _ completionHandler: @escaping (StitchResult<UpdateResult?>) -> Void) {


### PR DESCRIPTION
This PR changes the BSON representation of `CoreDocumentSynchronization.Config` so that uncommitted change events are stored as a BSON binary. This is because the update description in the sync config can have `.`'s in the field, which is not permitted by the drivers. This is the solution we use on Android currently.

No new tests are added, as this functionality was tested by the previously failing `testUpdateUsingUpdateDescription` test, and existing unit tests for the core doc sync config.

Drive-bys: 
* made the core doc sync config store fields as snake case
* added a persisted schema_version field to the doc sync config that we verify on decode
* made the `Sync` methods public instead of internal