### PR TITLE
STITCH-2268 add lint task to evergreen

### DIFF
--- a/.evg.yml
+++ b/.evg.yml
@@ -7,10 +7,11 @@ functions:
     - command: shell.exec
       params:
         script: |
-          git clone https://github.com/realm/SwiftLint
-          cd SwiftLint
-          git submodule update --init --recursive
-          make install
+          mkdir -p SwiftLint
+          pushd SwiftLint
+          curl -o swiftlint.zip -L https://github.com/realm/SwiftLint/releases/download/0.29.1/portable_swiftlint.zip
+          unzip swiftlint.zip
+          popd
   "setup_mongod":
     - command: shell.exec
       params:
@@ -25,7 +26,7 @@ functions:
           cd mongodb-*
           echo "starting mongod..."
           mkdir db_files
-          ./bin/mongod --dbpath ./db_files --port 26000
+          ./bin/mongod --dbpath ./db_files --port 26000 --replSet test
     - command: shell.exec
       params:
         script: |
@@ -33,6 +34,7 @@ functions:
           cd mongodb-*
           echo "waiting for mongod to start up"
           ./bin/mongo --nodb --eval 'assert.soon(function(x){try{var d = new Mongo("localhost:26000"); return true}catch(e){return false}}, "timed out connecting")'
+          ./bin/mongo --port 26000 --eval 'rs.initiate()'
           echo "mongod is up."
   "setup_stitch":
     - command: shell.exec
@@ -94,8 +96,11 @@ tasks:
         params: 
           script: |
             set -e
-            cd stitch-ios-sdk/StitchCore
-            swiftlint
+            pushd SwiftLint
+            export PATH=`pwd`:$PATH
+            popd
+            cd stitch-ios-sdk
+            contrib/lint_projects.sh
   - name: run_tests
     commands:
       - func: "fetch_source"
@@ -122,7 +127,7 @@ tasks:
             
             source ./creds
             if pgrep CoreSimulator; then pkill -9 CoreSimulator; fi
-            export DEVELOPER_DIR=/Applications/Xcode9.2.app
+            export DEVELOPER_DIR=/Applications/Xcode10.0.app
             cd stitch-ios-sdk
             export GEM_HOME=`pwd`
             export GEM_PATH=`pwd`
@@ -131,16 +136,17 @@ tasks:
             bin/pod setup
             bin/pod install
             echo "...testing core"
-            xcodebuild test -workspace Stitch.xcworkspace/ -scheme "All Core Tests" -destination 'platform=iOS Simulator,name=iPhone 8,OS=11.2'
+            xcodebuild test -verbose -workspace Stitch.xcworkspace/ -scheme "All Core Tests" -destination 'platform=iOS Simulator,name=iPhone 8,OS=12.0'
             echo "...testing Darwin"
-            xcodebuild test -workspace Stitch.xcworkspace/ -scheme "All Darwin Tests" -destination 'platform=iOS Simulator,name=iPhone 8,OS=11.2'
+            xcodebuild test -verbose -workspace Stitch.xcworkspace/ -scheme "All Darwin Tests" -destination 'platform=iOS Simulator,name=iPhone 8,OS=12.0'
 buildvariants:
-- name: macos-1013
-  display_name: MacOS 10.13
+- name: macos-1014-stitch
+  display_name: MacOS 10.14
   run_on:
-    - macos-1013
+    - macos-1014-stitch
   expansions:
-    mongodb_url: http://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-3.4.4.tgz
+    mongodb_url: http://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.2.tgz
     transpiler_target: node8-macos
   tasks:
     - name: run_tests
+    - name: lint

--- a/.evg.yml
+++ b/.evg.yml
@@ -7,6 +7,7 @@ functions:
     - command: shell.exec
       params:
         script: |
+          set -e
           mkdir -p SwiftLint
           pushd SwiftLint
           curl -o swiftlint.zip -L https://github.com/realm/SwiftLint/releases/download/0.29.1/portable_swiftlint.zip

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Internal/CoreStitchAuth+ExternalRequests.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Internal/CoreStitchAuth+ExternalRequests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import MongoSwift
+
+extension CoreStitchAuth {
+    /**
+     * Performs the logic of logging in this `CoreStitchAuth` as a new user with the provided credential. Can also
+     * perform a user link if the `asLinkRequest` parameter is true.
+     *
+     * - important: Callers of `doLogin` should be synchronized before calling in.
+     */
+    internal func doLogin(withCredential credential: StitchCredential, asLinkRequest: Bool) throws -> TStitchUser {
+        let response = try self.doLoginRequest(withCredential: credential, asLinkRequest: asLinkRequest)
+        let user = try self.processLoginResponse(withCredential: credential,
+                                                 forResponse: response,
+                                                 asLinkRequest: asLinkRequest)
+
+        onAuthEvent()
+        return user
+    }
+
+    /**
+     * Performs the login request against the Stitch server. If `asLinkRequest` is true, a link request is performed
+     * instead.
+     */
+    internal func doLoginRequest(withCredential credential: StitchCredential,
+                                 asLinkRequest: Bool) throws -> Response {
+        let reqBuilder = StitchDocRequestBuilder()
+
+        reqBuilder.with(method: .post)
+
+        if asLinkRequest {
+            reqBuilder.with(path: authRoutes.authProviderLinkRoute(withProviderName: credential.providerName))
+        } else {
+            reqBuilder.with(path: authRoutes.authProviderLoginRoute(withProviderName: credential.providerName))
+        }
+
+        var body = credential.material
+        self.attachAuthOptions(authBody: &body)
+        reqBuilder.with(document: body)
+
+        if !asLinkRequest {
+            return try self.requestClient.doRequest(reqBuilder.build())
+        }
+
+        return try doAuthenticatedRequest(
+            StitchAuthDocRequest.init(stitchRequest: reqBuilder.build(), document: body)
+        )
+    }
+
+    /**
+     * Processes the response of the login/link request, setting the authentication state if appropriate, and
+     * requesting the user profile in a separate request.
+     */
+    internal func processLoginResponse(withCredential credential: StitchCredential,
+                                       forResponse response: Response,
+                                       asLinkRequest: Bool) throws -> TStitchUser {
+        guard let body = response.body else {
+            throw StitchError.serviceError(
+                withMessage: StitchErrorCodable.genericErrorMessage(withStatusCode: response.statusCode),
+                withServiceErrorCode: .unknown
+            )
+        }
+
+        var decodedInfo: APIAuthInfoImpl!
+        do {
+            decodedInfo = try JSONDecoder().decode(APIAuthInfoImpl.self, from: body)
+        } catch {
+            throw StitchError.requestError(withError: error, withRequestErrorCode: .decodingError)
+        }
+
+        let oldAuthInfo = self.authInfo
+        let oldUser = self.user
+
+        // Provisionally set auth info so we can make a profile request
+        var newAPIAuthInfo: APIAuthInfo!
+        if let oldAuthInfo = oldAuthInfo { // If there was existing auth info (as in a link request)
+            let newAuthInfo = oldAuthInfo.merge(
+                withPartialInfo: decodedInfo,
+                fromOldInfo: oldAuthInfo
+            )
+            newAPIAuthInfo = newAuthInfo
+
+            self.authInfo = newAuthInfo
+        } else { // If there was no existing auth info
+            newAPIAuthInfo = decodedInfo
+            self.authStateHolder.apiAuthInfo = decodedInfo
+        }
+
+        var profile: StitchUserProfile!
+        do {
+            profile = try doGetUserProfile()
+        } catch let err {
+            // If this was a link request, back out of setting authInfo and reset any created user. This will keep
+            // the currently logged in user logged in if the profile request failed, and in this particular edge case
+            // the user is linked, but they are logged in with their older credentials.
+            if asLinkRequest {
+                self.authInfo = oldAuthInfo
+                currentUser = oldUser
+            } else { // otherwise if this was a normal login request, log the user out
+                self.authInfo = nil
+                currentUser = nil
+            }
+
+            throw err
+        }
+
+        // Finally set the info and user
+        self.authInfo = StoreAuthInfo.init(
+            withAPIAuthInfo: newAPIAuthInfo,
+            withExtendedAuthInfo: ExtendedAuthInfoImpl.init(loggedInProviderType: type(of: credential).providerType,
+                                                            loggedInProviderName: credential.providerName,
+                                                            userProfile: profile))
+
+        // Persist auth info to storage, and return the resulting StitchUser
+        return try persistAuthInfoToStorage(forCredential: credential, withProfile: profile)
+    }
+
+    private func persistAuthInfoToStorage(
+        forCredential credential: StitchCredential,
+        withProfile profile: StitchUserProfile
+    ) throws -> TStitchUser {
+        // Persist auth info to storage
+        do {
+            try self.authInfo?.write(toStorage: &storage)
+        } catch {
+            throw StitchError.clientError(withClientErrorCode: .couldNotPersistAuthInfo)
+        }
+
+        self.currentUser =
+            userFactory
+                .makeUser(
+                    withID: authInfo!.userID,
+                    withLoggedInProviderType: type(of: credential).providerType,
+                    withLoggedInProviderName: credential.providerName,
+                    withUserProfile: profile)
+        return self.currentUser!
+    }
+
+    /**
+     * Enum representing the keys for additional auth options that may be attached to the body of the authentication
+     * request sent to the Stitch server on login or link.
+     */
+    private enum AuthKey: String {
+        case options
+        case device
+    }
+
+    /**
+     * Attaches authentication options to the BSON document passed in as the `authBody` parameter. Necessary for the
+     * the login request.
+     */
+    private func attachAuthOptions(authBody: inout Document) {
+        authBody[AuthKey.options.rawValue] = [AuthKey.device.rawValue: deviceInfo] as Document
+    }
+
+    /**
+     * Performs a request against the Stitch server to get the currently authenticated user's profile.
+     */
+    internal func doGetUserProfile() throws -> StitchUserProfile {
+        let response = try doAuthenticatedRequest(
+            StitchAuthRequestBuilder()
+                .with(method: .get)
+                .with(path: self.authRoutes.profileRoute)
+                .build()
+        )
+
+        var decodedProfile: APICoreUserProfileImpl!
+        do {
+            decodedProfile = try JSONDecoder.init().decode(APICoreUserProfileImpl.self, from: response.body!)
+        } catch {
+            throw StitchError.requestError(withError: error, withRequestErrorCode: .decodingError)
+        }
+
+        return StitchUserProfileImpl.init(userType: decodedProfile.userType,
+                                          identities: decodedProfile.identities,
+                                          data: decodedProfile.data)
+    }
+
+    /**
+     * Performs a logout request against the Stitch server.
+     */
+    @discardableResult
+    internal func doLogout() throws -> Response {
+        return try self.doAuthenticatedRequest(
+            StitchAuthRequestBuilder()
+                .withRefreshToken()
+                .with(path: authRoutes.sessionRoute)
+                .with(method: .delete)
+                .build()
+        )
+    }
+
+    /**
+     * Performs the request necessary to refresh an access token.
+     *
+     * - return: a new APIAccessToken representing the refreshed access token.
+     */
+    internal func doRefreshAccessToken() throws -> APIAccessToken {
+        let response = try self.doAuthenticatedRequest(
+            StitchAuthRequestBuilder()
+                .withRefreshToken()
+                .with(path: self.authRoutes.sessionRoute)
+                .with(method: .post)
+                .build()
+        )
+
+        var newAccessToken: APIAccessToken!
+        do {
+            newAccessToken = try JSONDecoder().decode(APIAccessToken.self,
+                                                      from: response.body!)
+        } catch let err {
+            throw StitchError.requestError(withError: err, withRequestErrorCode: .decodingError)
+        }
+
+        return newAccessToken
+    }
+}

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Internal/CoreStitchAuth.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Internal/CoreStitchAuth.swift
@@ -31,7 +31,7 @@ open class CoreStitchAuth<TStitchUser>: StitchAuthRequestClient where TStitchUse
     /**
      * A `TStitchUser` object that represents the currently authenticated user, or `nil` if no one is authenticated.
      */
-    private var currentUser: TStitchUser?
+    internal var currentUser: TStitchUser?
 
     /**
      * The `StitchRequestClient` used by the `CoreStitchAuth` to make requests to the Stitch server.
@@ -257,186 +257,6 @@ open class CoreStitchAuth<TStitchUser>: StitchAuthRequestClient where TStitchUse
     // MARK: Internal Methods
 
     /**
-     * Performs the logic of logging in this `CoreStitchAuth` as a new user with the provided credential. Can also
-     * perform a user link if the `asLinkRequest` parameter is true.
-     *
-     * - important: Callers of `doLogin` should be synchronized before calling in.
-     */
-    private func doLogin(withCredential credential: StitchCredential, asLinkRequest: Bool) throws -> TStitchUser {
-        let response = try self.doLoginRequest(withCredential: credential, asLinkRequest: asLinkRequest)
-        let user = try self.processLoginResponse(withCredential: credential,
-                                                 forResponse: response,
-                                                 asLinkRequest: asLinkRequest)
-
-        onAuthEvent()
-        return user
-    }
-
-    /**
-     * Enum representing the keys for additional auth options that may be attached to the body of the authentication
-     * request sent to the Stitch server on login or link.
-     */
-    private enum AuthKey: String {
-        case options
-        case device
-    }
-
-    /**
-     * Attaches authentication options to the BSON document passed in as the `authBody` parameter. Necessary for the
-     * the login request.
-     */
-    private func attachAuthOptions(authBody: inout Document) {
-        authBody[AuthKey.options.rawValue] = [AuthKey.device.rawValue: deviceInfo] as Document
-    }
-
-    /**
-     * Performs the login request against the Stitch server. If `asLinkRequest` is true, a link request is performed
-     * instead.
-     */
-    private func doLoginRequest(withCredential credential: StitchCredential,
-                                asLinkRequest: Bool) throws -> Response {
-        let reqBuilder = StitchDocRequestBuilder()
-
-        reqBuilder.with(method: .post)
-
-        if asLinkRequest {
-            reqBuilder.with(path: authRoutes.authProviderLinkRoute(withProviderName: credential.providerName))
-        } else {
-            reqBuilder.with(path: authRoutes.authProviderLoginRoute(withProviderName: credential.providerName))
-        }
-
-        var body = credential.material
-        self.attachAuthOptions(authBody: &body)
-        reqBuilder.with(document: body)
-
-        if !asLinkRequest {
-            return try self.requestClient.doRequest(reqBuilder.build())
-        }
-
-        return try doAuthenticatedRequest(
-            StitchAuthDocRequest.init(stitchRequest: reqBuilder.build(), document: body)
-        )
-    }
-
-    /**
-     * Processes the response of the login/link request, setting the authentication state if appropriate, and
-     * requesting the user profile in a separate request.
-     */
-    private func processLoginResponse(withCredential credential: StitchCredential,
-                                      forResponse response: Response,
-                                      asLinkRequest: Bool) throws -> TStitchUser {
-        guard let body = response.body else {
-            throw StitchError.serviceError(
-                withMessage: StitchErrorCodable.genericErrorMessage(withStatusCode: response.statusCode),
-                withServiceErrorCode: .unknown
-            )
-        }
-
-        var decodedInfo: APIAuthInfoImpl!
-        do {
-            decodedInfo = try JSONDecoder().decode(APIAuthInfoImpl.self, from: body)
-        } catch {
-            throw StitchError.requestError(withError: error, withRequestErrorCode: .decodingError)
-        }
-
-        let oldAuthInfo = self.authInfo
-        let oldUser = self.user
-
-        // Provisionally set auth info so we can make a profile request
-        var newAPIAuthInfo: APIAuthInfo!
-        if let oldAuthInfo = oldAuthInfo { // If there was existing auth info (as in a link request)
-            let newAuthInfo = oldAuthInfo.merge(
-                withPartialInfo: decodedInfo,
-                fromOldInfo: oldAuthInfo
-            )
-            newAPIAuthInfo = newAuthInfo
-
-            self.authInfo = newAuthInfo
-        } else { // If there was no existing auth info
-            newAPIAuthInfo = decodedInfo
-            self.authStateHolder.apiAuthInfo = decodedInfo
-        }
-
-        var profile: StitchUserProfile!
-        do {
-            profile = try doGetUserProfile()
-        } catch let err {
-            // If this was a link request, back out of setting authInfo and reset any created user. This will keep
-            // the currently logged in user logged in if the profile request failed, and in this particular edge case
-            // the user is linked, but they are logged in with their older credentials.
-            if asLinkRequest {
-                self.authInfo = oldAuthInfo
-                currentUser = oldUser
-            } else { // otherwise if this was a normal login request, log the user out
-                self.authInfo = nil
-                currentUser = nil
-            }
-
-            throw err
-        }
-
-        // Finally set the info and user
-        self.authInfo = StoreAuthInfo.init(
-            withAPIAuthInfo: newAPIAuthInfo,
-            withExtendedAuthInfo: ExtendedAuthInfoImpl.init(loggedInProviderType: type(of: credential).providerType,
-                                                            loggedInProviderName: credential.providerName,
-                                                            userProfile: profile))
-
-        // Persist auth info to storage
-        do {
-            try self.authInfo?.write(toStorage: &storage)
-        } catch {
-            throw StitchError.clientError(withClientErrorCode: .couldNotPersistAuthInfo)
-        }
-
-        self.currentUser =
-            userFactory
-                .makeUser(
-                    withID: authInfo!.userID,
-                    withLoggedInProviderType: type(of: credential).providerType,
-                    withLoggedInProviderName: credential.providerName,
-                    withUserProfile: profile)
-        return self.currentUser!
-    }
-
-    /**
-     * Performs a request against the Stitch server to get the currently authenticated user's profile.
-     */
-    private func doGetUserProfile() throws -> StitchUserProfile {
-        let response = try doAuthenticatedRequest(
-            StitchAuthRequestBuilder()
-                .with(method: .get)
-                .with(path: self.authRoutes.profileRoute)
-                .build()
-        )
-
-        var decodedProfile: APICoreUserProfileImpl!
-        do {
-            decodedProfile = try JSONDecoder.init().decode(APICoreUserProfileImpl.self, from: response.body!)
-        } catch {
-            throw StitchError.requestError(withError: error, withRequestErrorCode: .decodingError)
-        }
-
-        return StitchUserProfileImpl.init(userType: decodedProfile.userType,
-                                          identities: decodedProfile.identities,
-                                          data: decodedProfile.data)
-    }
-
-    /**
-     * Performs a logout request against the Stitch server.
-     */
-    @discardableResult
-    private func doLogout() throws -> Response {
-        return try self.doAuthenticatedRequest(
-            StitchAuthRequestBuilder()
-                .withRefreshToken()
-                .with(path: authRoutes.sessionRoute)
-                .with(method: .delete)
-                .build()
-        )
-    }
-
-    /**
      * Clears the `CoreStitchAuth`'s authentication state, as well as associated authentication state in underlying
      * storage.
      */
@@ -483,21 +303,7 @@ open class CoreStitchAuth<TStitchUser>: StitchAuthRequestClient where TStitchUse
         objc_sync_enter(authOperationLock)
         defer { objc_sync_exit(authOperationLock) }
 
-        let response = try self.doAuthenticatedRequest(
-            StitchAuthRequestBuilder()
-                .withRefreshToken()
-                .with(path: self.authRoutes.sessionRoute)
-                .with(method: .post)
-                .build()
-        )
-
-        var newAccessToken: APIAccessToken!
-        do {
-            newAccessToken = try JSONDecoder().decode(APIAccessToken.self,
-                                                      from: response.body!)
-        } catch let err {
-            throw StitchError.requestError(withError: err, withRequestErrorCode: .decodingError)
-        }
+        let newAccessToken = try doRefreshAccessToken()
 
         self.authInfo = self.authInfo?.refresh(withNewAccessToken: newAccessToken)
 

--- a/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
+++ b/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		118125DA21CBF916009AAC87 /* CoreStitchAuth+ExternalRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118125D921CBF916009AAC87 /* CoreStitchAuth+ExternalRequests.swift */; };
 		3F282A0280D2DDAD143A9B4F /* Pods_StitchCoreSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 13FA6FF839A9BF0FA4286528 /* Pods_StitchCoreSDK.framework */; };
 		498062702185B6AF00E2A3A2 /* StitchUserProfileUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498062562185B6AF00E2A3A2 /* StitchUserProfileUnitTests.swift */; };
 		498062712185B6AF00E2A3A2 /* CoreUserPasswordAuthProviderClientUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498062592185B6AF00E2A3A2 /* CoreUserPasswordAuthProviderClientUnitTests.swift */; };
@@ -126,6 +127,7 @@
 
 /* Begin PBXFileReference section */
 		00721A8AA4E132139B3B0168 /* Pods-StitchCoreSDKTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDKTests.debug.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDKTests/Pods-StitchCoreSDKTests.debug.xcconfig"; sourceTree = "<group>"; };
+		118125D921CBF916009AAC87 /* CoreStitchAuth+ExternalRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreStitchAuth+ExternalRequests.swift"; sourceTree = "<group>"; };
 		13FA6FF839A9BF0FA4286528 /* Pods_StitchCoreSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StitchCoreSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D988771353A1369B3BEF6E2 /* Pods-StitchCoreSDK-StitchCoreSDKMocks.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchCoreSDK-StitchCoreSDKMocks.debug.xcconfig"; path = "Target Support Files/Pods-StitchCoreSDK-StitchCoreSDKMocks/Pods-StitchCoreSDK-StitchCoreSDKMocks.debug.xcconfig"; sourceTree = "<group>"; };
 		363D0185C367AB395C01ED51 /* Pods_StitchCoreSDKTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_StitchCoreSDKTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -495,6 +497,7 @@
 				4980622F2185B6A100E2A3A2 /* AuthInfo.swift */,
 				498062302185B6A100E2A3A2 /* CoreStitchAuth+StitchAuthRequestClient.swift */,
 				498062312185B6A100E2A3A2 /* AuthStateHolder.swift */,
+				118125D921CBF916009AAC87 /* CoreStitchAuth+ExternalRequests.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";
@@ -1027,6 +1030,7 @@
 				4980628C2185B6BC00E2A3A2 /* CoreUserAPIKeyAuthProviderClient.swift in Sources */,
 				4980628D2185B6BC00E2A3A2 /* UserAPIKeyCredential.swift in Sources */,
 				4980628E2185B6BC00E2A3A2 /* FacebookAuthProvider.swift in Sources */,
+				118125DA21CBF916009AAC87 /* CoreStitchAuth+ExternalRequests.swift in Sources */,
 				4980628F2185B6BC00E2A3A2 /* FacebookCredential.swift in Sources */,
 				498062902185B6BC00E2A3A2 /* UserPasswordAuthProvider.swift in Sources */,
 				498062912185B6BC00E2A3A2 /* CoreUserPasswordAuthProviderClient.swift in Sources */,

--- a/Core/StitchCoreSDK/Tests/StitchCoreSDKTests/Internal/Net/StitchRequestClientUnitTests.swift
+++ b/Core/StitchCoreSDK/Tests/StitchCoreSDKTests/Internal/Net/StitchRequestClientUnitTests.swift
@@ -69,9 +69,8 @@ class StitchRequestClientUnitTests: StitchXCTestCase {
 
         XCTAssertEqual(response.statusCode, 200)
 
-        // TODO: uncomment when SWIFT-104 is completed
-        // let expected = ["hello": "world", "a": 42] as [String : BSONValue]
-        // XCTAssertEqual(expected, BSONDecoder().decode([String: BSONValue].self, from: response.body!))
+        let expected = ["hello": "world", "a": 42] as Document
+        XCTAssertEqual(expected, try Document.init(fromJSON: response.body!))
 
         transport.mockRoundTrip.clearStubs()
 
@@ -230,9 +229,8 @@ class StitchRequestClientUnitTests: StitchXCTestCase {
 
         XCTAssertEqual(response.statusCode, 200)
 
-        // TODO: uncomment when SWIFT-104 is completed
-        // let expected = ["hello": "world", "a": 42] as [String : BSONValue]
-        // XCTAssertEqual(expected, BSONDecoder().decode([String: BSONValue].self, from: response.body!))
+        let expected = ["hello": "world", "a": 42] as Document
+        XCTAssertEqual(expected, try Document.init(fromJSON: response.body!))
 
         transport.mockRoundTrip.clearStubs()
 

--- a/contrib/lint_projects.sh
+++ b/contrib/lint_projects.sh
@@ -21,9 +21,7 @@ set -e
 pushd Core
 
 pushd StitchCoreSDK
-echo "currently ignoring linter warnings in StitchCoreSDK until STITCH-2269 is completed"
-# TODO: when STITCH-2269 is completed, remove the echo and make this a "check_swiftlint"
-swiftlint
+check_swiftlint
 popd
 
 pushd StitchCoreTestUtils


### PR DESCRIPTION
Adds a working lint task to evergreen.

This also drive-bys most of the necessary changes for STITCH-2266, but until the Evergreen team fixes the xcodebuild segfault problem on the hosts, STITCH-2266 can't be completed.