### PR TITLE
DOCSP-3936 Push docs to docs.mongodb.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The official [MongoDB Stitch](https://stitch.mongodb.com/) SDK for iOS/Swift.
 - [Example Usage](#example-usage)
 
 ## Documentation
-* [API/Jazzy Documentation](https://s3.amazonaws.com/stitch-sdks/swift/docs/4.1.2/index.html)
+* [API/Jazzy Documentation](https://docs.mongodb.com/stitch-sdks/swift/4.1.2/index.html)
 * [MongoDB Stitch Documentation](https://docs.mongodb.com/stitch/)
 
 ## Discussion

--- a/contrib/publish_docs.sh
+++ b/contrib/publish_docs.sh
@@ -18,12 +18,12 @@ fi
 
 if [ -z "$VERSION_QUALIFIER" ]; then
 	# Publish to MAJOR, MAJOR.MINOR
-	aws s3 cp docs s3://stitch-sdks/swift/docs/$VERSION_MAJOR --recursive --acl public-read
-	aws s3 cp docs s3://stitch-sdks/swift/docs/$VERSION_MAJOR.$VERSION_MINOR --recursive --acl public-read
+	aws s3 cp docs s3://stitch-sdks/stitch-sdks/swift/$VERSION_MAJOR --recursive --acl public-read
+	aws s3 cp docs s3://stitch-sdks/stitch-sdks/swift/$VERSION_MAJOR.$VERSION_MINOR --recursive --acl public-read
 fi
 
 # Publish to full version
-aws s3 cp docs s3://stitch-sdks/swift/docs/$VERSION --recursive --acl public-read
+aws s3 cp docs s3://stitch-sdks/stitch-sdks/swift/$VERSION --recursive --acl public-read
 
 BRANCH_NAME=`git branch | grep -e "^*" | cut -d' ' -f 2`
-aws s3 cp docs s3://stitch-sdks/swift/docs/branch/$BRANCH_NAME --recursive --acl public-read
+aws s3 cp docs s3://stitch-sdks/stitch-sdks/swift/branch/$BRANCH_NAME --recursive --acl public-read


### PR DESCRIPTION
This updates the destination to a stitch-sdks subdirectory on the
existing bucket so that docs.mongodb.com/stitch-sdks can find it.
(Not sure, this was specifically required by techops.)

Removes the /docs/ part which is arguably redundant now that it is
hosted on docs.mongodb.com.

Also updates the README for the new docs URL. Please publish
the docs and check that the new URL works.