### PR TITLE
STITCH-2564 fix racy testInsertInsertConflict test by fixing some testing bugs

### DIFF
--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Internal/DataSynchronizer.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Internal/DataSynchronizer.swift
@@ -1338,8 +1338,9 @@ public class DataSynchronizer: NetworkStateDelegate, FatalErrorListener {
                 return
             }
 
+            instanceChangeStreamDelegate.start()
+
             if isSyncThreadEnabled {
-                instanceChangeStreamDelegate.start()
                 self.syncWorkItem = DispatchWorkItem { [weak self] in
                     repeat {
                         guard let dataSync = self else {
@@ -2158,6 +2159,12 @@ public class DataSynchronizer: NetworkStateDelegate, FatalErrorListener {
         guard ids.count > 0 else { return [] }
         return try self.remoteCollection(for: nsConfig.namespace)
             .find(["$or": ids]).toArray()
+    }
+
+    public var allStreamsAreOpen: Bool {
+        return syncLock.write {
+            return self.instanceChangeStreamDelegate.allStreamsAreOpen
+        }
     }
 
     // MARK: Utilities

--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Internal/InstanceChangeStreamDelegate.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Internal/InstanceChangeStreamDelegate.swift
@@ -88,6 +88,15 @@ class InstanceChangeStreamDelegate {
         }
     }
 
+    var allStreamsAreOpen: Bool {
+        return instanceLock.write {
+            for (_, streamer) in self.namespaceToStreamDelegates where streamer.state != .open {
+                return false
+            }
+            return true
+        }
+    }
+
     subscript(namespace: MongoNamespace) -> NamespaceChangeStreamDelegate? {
         return instanceLock.read {
             return namespaceToStreamDelegates[namespace]

--- a/Darwin/StitchDarwinCoreTestUtils/StitchDarwinCoreTestUtils/BaseStitchIntTestCocoaTouch.swift
+++ b/Darwin/StitchDarwinCoreTestUtils/StitchDarwinCoreTestUtils/BaseStitchIntTestCocoaTouch.swift
@@ -19,8 +19,8 @@ public class TestNetworkMonitor: NetworkMonitor {
     private var delegates = [WeakNetworkStateDelegate]()
 
     public var state: NetworkState = .connected {
-        didSet {
-            delegates.forEach { $0.weak?.on(stateChangedFor: state) }
+        didSet(newValue) {
+            delegates.forEach { $0.weak?.on(stateChangedFor: newValue) }
         }
     }
 


### PR DESCRIPTION
As per the Slack discussion, this PR fixes various issues with testing that caused a race condition in `testInsertInsertConflict`, and could have caused other issues in future tests. This should make the tests a lot more stable, and the test environment will more accurately reflect the real environment. This also matches more closely with how the tests work in the Android SDK

There were three issues:

1. `SyncTestContext.streamAndSync` was stopping the DataSynchronizer and starting the stream (via the `InstanceChangeStreamDelegate`) if the stream state was closed, but this was causing the stream to sometimes be opened more than once (setting documents stale in the process, causing the failing test), because the actual sync logic already starts the stream so it wasn't necessary. I changed `streamAndSync` to not change anything about the DataSynchronizer, and to wait for streams to open before doing the sync pass.
2. In `DataSynchronizer.start()`, the stream was not getting opened if the sync thread was disabled (which it is for testing). I moved this to happen regardless of whether the sync thread is enabled, since the stream starting is not related to the sync thread.
3. The `TestNetworkMonitor` in `BaseStitchIntTestCocoaTouch` was not properly dispatching network state changes to the `DataSynchronizer`, because of a Swift nuance with `didSet`. We were always dispatching the previous state, not the new state, so the DataSynchronizer never actually started a new stream when the network state was modified by the test.

Issues 2 and 3 are probably the reason why the race-condition causing workaround in 1 was made