### PR TITLE
STITCH-2559

### DIFF
--- a/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Internal/DataSynchronizer.swift
+++ b/Core/Services/StitchCoreRemoteMongoDBService/Sources/StitchCoreRemoteMongoDBService/Sync/Internal/DataSynchronizer.swift
@@ -2279,10 +2279,10 @@ public class DataSynchronizer: NetworkStateDelegate, FatalErrorListener {
 
     private func latestStaleDocumentsFromRemote(nsConfig: NamespaceSynchronization,
                                                 staleIds: Set<AnyBSONValue>) throws -> [Document] {
-        let ids = staleIds.map { ["_id": $0.value ] as Document }
+        let ids = staleIds.map { $0.value }
         guard ids.count > 0 else { return [] }
         return try self.remoteCollection(for: nsConfig.namespace)
-            .find(["$or": ids]).toArray()
+            .find(["_id": ["$in": ids] as Document]).toArray()
     }
 
     public var allStreamsAreOpen: Bool {

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService.xcodeproj/project.pbxproj
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		112659ED223329D800F826BA /* Sync+CRUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112659EC223329D800F826BA /* Sync+CRUD.swift */; };
 		1135F7DB2215D88500300A19 /* ChangeStreamSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1135F7DA2215D88500300A19 /* ChangeStreamSession.swift */; };
 		1135F7DD2215D89000300A19 /* ChangeStreamDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1135F7DC2215D89000300A19 /* ChangeStreamDelegate.swift */; };
 		1159637820D029EA00B0179B /* StitchRemoteMongoDBServiceExports.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1159637720D029EA00B0179B /* StitchRemoteMongoDBServiceExports.swift */; };
@@ -65,6 +66,7 @@
 /* Begin PBXFileReference section */
 		0A5F1FC60AEE251C61086EA4 /* Pods-StitchRemoteMongoDBService.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchRemoteMongoDBService.release.xcconfig"; path = "Target Support Files/Pods-StitchRemoteMongoDBService/Pods-StitchRemoteMongoDBService.release.xcconfig"; sourceTree = "<group>"; };
 		0F05E8EDBE4F2463B891B9DD /* Pods-StitchRemoteMongoDBServiceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StitchRemoteMongoDBServiceTests.release.xcconfig"; path = "Target Support Files/Pods-StitchRemoteMongoDBServiceTests/Pods-StitchRemoteMongoDBServiceTests.release.xcconfig"; sourceTree = "<group>"; };
+		112659EC223329D800F826BA /* Sync+CRUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sync+CRUD.swift"; sourceTree = "<group>"; };
 		1135F7DA2215D88500300A19 /* ChangeStreamSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeStreamSession.swift; sourceTree = "<group>"; };
 		1135F7DC2215D89000300A19 /* ChangeStreamDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeStreamDelegate.swift; sourceTree = "<group>"; };
 		1159637720D029EA00B0179B /* StitchRemoteMongoDBServiceExports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchRemoteMongoDBServiceExports.swift; sourceTree = "<group>"; };
@@ -147,6 +149,7 @@
 				1169219120C9D2A100930DD8 /* RemoteMongoDatabase.swift */,
 				1169219520C9FE3500930DD8 /* RemoteMongoReadOperation.swift */,
 				491F9B4B21A3545500802A4D /* Sync.swift */,
+				112659EC223329D800F826BA /* Sync+CRUD.swift */,
 				1159637720D029EA00B0179B /* StitchRemoteMongoDBServiceExports.swift */,
 				1169216C20C9D04C00930DD8 /* Info.plist */,
 				1135F7DA2215D88500300A19 /* ChangeStreamSession.swift */,
@@ -425,6 +428,7 @@
 				1169219620C9FE3500930DD8 /* RemoteMongoReadOperation.swift in Sources */,
 				491F9B4C21A3545500802A4D /* Sync.swift in Sources */,
 				1135F7DB2215D88500300A19 /* ChangeStreamSession.swift in Sources */,
+				112659ED223329D800F826BA /* Sync+CRUD.swift in Sources */,
 				1159637820D029EA00B0179B /* StitchRemoteMongoDBServiceExports.swift in Sources */,
 				116ABEB0221CA01C003C1D18 /* InternalChangeStreamDelegate.swift in Sources */,
 			);

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync+CRUD.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync+CRUD.swift
@@ -1,0 +1,275 @@
+import Foundation
+import MongoSwift
+import StitchCore
+import StitchCoreRemoteMongoDBService
+
+/**
+ * A set of CRUD operations for a synchronized collection.
+ */
+public extension Sync {
+    /**
+     Counts the number of documents in the collection that have been synchronized with the remote.
+
+     - returns: the number of documents in the collection
+     */
+    public func count(_ completionHandler: @escaping (StitchResult<Int>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(
+                    .success(result: try self.proxy.count()))
+            } catch {
+                completionHandler(
+                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
+            }
+        }
+    }
+
+    /**
+     Counts the number of documents in the collection that have been synchronized with the remote
+     according to the given options.
+
+     - parameter filter:  the query filter
+     - parameter options: the options describing the count
+     - parameter completionHandler: the callback for the count result
+     - returns: the number of documents in the collection
+     */
+    public func count(filter: Document,
+                      options: SyncCountOptions?,
+                      _ completionHandler: @escaping (StitchResult<Int>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(
+                    .success(result: try self.proxy.count(filter: filter,
+                                                          options: options)))
+            } catch {
+                completionHandler(
+                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
+            }
+        }
+    }
+
+    /**
+     Finds all documents in the collection that have been synchronized with the remote.
+
+     - parameter completionHandler: the callback for the find result
+     - returns: the find iterable interface
+     */
+    public func find(_ completionHandler: @escaping (StitchResult<MongoCursor<DocumentT>>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(
+                    .success(result: try self.proxy.find()))
+            } catch {
+                completionHandler(
+                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
+            }
+        }
+    }
+
+    /**
+     Finds all documents in the collection that have been synchronized with the remote.
+
+     - parameter filter: the query filter for this find op
+     - parameter options: the options for this find op
+     - parameter completionHandler: the callback for the find result
+     - returns: the find iterable interface
+     */
+    public func find(
+        filter: Document,
+        options: SyncFindOptions? = nil,
+        _ completionHandler: @escaping (StitchResult<MongoCursor<DocumentT>>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(
+                    .success(result: try self.proxy.find(filter: filter, options: options)))
+            } catch {
+                completionHandler(
+                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
+            }
+        }
+    }
+
+    /**
+     Finds a document in the collection that has been synchronized with the remote.
+
+     - parameter filter: the query filter for this find op
+     - parameter options: the options for this find op
+     - parameter completionHandler: the callback for the find result
+     - returns: the document or nil if no such document existss
+     */
+    public func findOne(
+        filter: Document? = nil,
+        options: SyncFindOptions? = nil,
+        _ completionHandler: @escaping (StitchResult<DocumentT?>) -> Void) {
+        queue.async {
+            do {
+                let newFilter: Document!
+                if let filter = filter { newFilter = filter} else {newFilter = Document.init()}
+                completionHandler(
+                    .success(result: try self.proxy.findOne(filter: newFilter, options: options)))
+            } catch {
+                completionHandler(
+                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
+            }
+        }
+    }
+
+    /**
+     Aggregates documents that have been synchronized with the remote
+     according to the specified aggregation pipeline.
+
+     - parameter pipeline: the aggregation pipeline
+     - parameter options: the options for this aggregate op
+     - returns: an iterable containing the result of the aggregation operation
+     */
+    public func aggregate(pipeline: [Document],
+                          options: AggregateOptions?,
+                          _ completionHandler: @escaping (StitchResult<MongoCursor<Document>>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(
+                    .success(result: try self.proxy.aggregate(pipeline: pipeline, options: options)))
+            } catch {
+                completionHandler(
+                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
+            }
+        }
+    }
+
+    /**
+     Inserts the provided document. If the document is missing an identifier, the client should
+     generate one. Syncs the newly inserted document against the remote.
+
+     - parameter document: the document to insert
+     - returns: the result of the insert one operation
+     */
+    public func insertOne(document: DocumentT,
+                          _ completionHandler: @escaping (StitchResult<SyncInsertOneResult?>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(.success(result: try self.proxy.insertOne(document: document)))
+            } catch {
+                completionHandler(.failure(
+                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
+                    ))
+            }
+        }
+    }
+
+    /**
+     Inserts one or more documents. Syncs the newly inserted documents against the remote.
+
+     - parameter documents: the documents to insert
+     - returns: the result of the insert many operation
+     */
+    public func insertMany(documents: [DocumentT],
+                           _ completionHandler: @escaping (StitchResult<SyncInsertManyResult?>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(.success(result: try self.proxy.insertMany(documents: documents)))
+            } catch {
+                completionHandler(.failure(
+                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
+                    ))
+            }
+        }
+    }
+
+    /**
+     Removes at most one document from the collection that has been synchronized with the remote
+     that matches the given filter.  If no documents match, the collection is not
+     modified.
+
+     - parameter filter: the query filter to apply the the delete operation
+     - returns: the result of the remove one operation
+     */
+    public func deleteOne(filter: Document,
+                          _ completionHandler: @escaping (StitchResult<SyncDeleteResult?>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(.success(result: try self.proxy.deleteOne(filter: filter)))
+            } catch {
+                completionHandler(.failure(
+                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
+                    ))
+            }
+        }
+    }
+
+    /**
+     Removes all documents from the collection that have been synchronized with the remote
+     that match the given query filter.  If no documents match, the collection is not modified.
+
+     - parameter filter: the query filter to apply the the delete operation
+     - returns: the result of the remove many operation
+     */
+    public func deleteMany(filter: Document,
+                           _ completionHandler: @escaping (StitchResult<SyncDeleteResult?>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(.success(result: try self.proxy.deleteMany(filter: filter)))
+            } catch {
+                completionHandler(.failure(
+                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
+                    ))
+            }
+        }
+    }
+
+    /**
+     Update a single document in the collection that have been synchronized with the remote
+     according to the specified arguments. If the update results in an upsert,
+     the newly upserted document will automatically become synchronized.
+
+     - parameter filter: a document describing the query filter, which may not be null.
+     - parameter update: a document describing the update, which may not be null. The update to
+     apply must include only update operators.
+     - returns: the result of the update one operation
+     */
+    public func updateOne(filter: Document,
+                          update: Document,
+                          options: SyncUpdateOptions?,
+                          _ completionHandler: @escaping (StitchResult<SyncUpdateResult?>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(.success(
+                    result: try self.proxy.updateOne(filter: filter,
+                                                     update: update,
+                                                     options: options)))
+            } catch {
+                completionHandler(.failure(
+                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
+                    ))
+            }
+        }
+    }
+
+    /**
+     Update all documents in the collection that have been synchronized with the remote
+     according to the specified arguments. If the update results in an upsert,
+     the newly upserted document will automatically become synchronized.
+
+     - parameter filter: a document describing the query filter, which may not be null.
+     - parameter update: a document describing the update, which may not be null. The update to
+     apply must include only update operators.
+     - parameter updateOptions: the options to apply to the update operation
+     - returns: the result of the update many operation
+     */
+    public func updateMany(filter: Document,
+                           update: Document,
+                           options: SyncUpdateOptions?,
+                           _ completionHandler: @escaping (StitchResult<SyncUpdateResult?>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(.success(
+                    result: try self.proxy.updateMany(filter: filter,
+                                                      update: update,
+                                                      options: options)))
+            } catch {
+                completionHandler(.failure(
+                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
+                    ))
+            }
+        }
+    }
+}

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
@@ -30,11 +30,11 @@ public class Sync<DocumentT: Codable> {
         _ remoteEvent: ChangeEvent<DocumentT>)  throws -> DocumentT?,
         changeEventDelegate: ((_ documentId: BSONValue, _ event: ChangeEvent<DocumentT>) -> Void)? = nil,
         errorListener:  ((_ error: DataSynchronizerError, _ documentId: BSONValue?) -> Void)? = nil,
-        _ completionHandler: ((StitchResult<Void>) -> Void)) {
+        _ completionHandler: @escaping (StitchResult<Void>) -> Void) {
         queue.async {
-            self.proxy.configure(conflictHandler: conflictHandler,
-                                 changeEventDelegate: changeEventDelegate,
-                                 errorListener: errorListener)
+            completionHandler(.success(result: self.proxy.configure(conflictHandler: conflictHandler,
+                                                                    changeEventDelegate: changeEventDelegate,
+                                                                    errorListener: errorListener)))
         }
     }
 
@@ -51,13 +51,12 @@ public class Sync<DocumentT: Codable> {
         conflictHandler: CH,
         changeEventDelegate: CED? = nil,
         errorListener: ErrorListener? = nil,
-        _ completionHandler: ((StitchResult<Void>) -> Void)
+        _ completionHandler: @escaping (StitchResult<Void>) -> Void
     ) where CH.DocumentT == DocumentT, CED.DocumentT == DocumentT {
-
         queue.async {
-            self.proxy.configure(conflictHandler: conflictHandler,
-                                 changeEventDelegate: changeEventDelegate,
-                                 errorListener: errorListener)
+            completionHandler(.success(result: self.proxy.configure(conflictHandler: conflictHandler,
+                                                                    changeEventDelegate: changeEventDelegate,
+                                                                    errorListener: errorListener)))
         }
     }
 

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
@@ -8,7 +8,7 @@ import StitchCoreRemoteMongoDBService
  */
 public class Sync<DocumentT: Codable> {
     internal let proxy: CoreSync<DocumentT>
-    private let queue = DispatchQueue.init(label: "sync", qos: .userInitiated)
+    internal let queue = DispatchQueue.init(label: "sync", qos: .userInitiated)
 
     internal init(proxy: CoreSync<DocumentT>) {
         self.proxy = proxy
@@ -21,6 +21,7 @@ public class Sync<DocumentT: Codable> {
      - parameter changeEventDelegate: the event listener to invoke when a change event happens for the
      document.
      - parameter errorListener: the error listener to invoke when an irrecoverable error occurs
+     - parameter completionHandler: the handler to execute when configuration is complete
      */
     public func configure(
         conflictHandler: @escaping (
@@ -28,10 +29,13 @@ public class Sync<DocumentT: Codable> {
         _ localEvent: ChangeEvent<DocumentT>,
         _ remoteEvent: ChangeEvent<DocumentT>)  throws -> DocumentT?,
         changeEventDelegate: ((_ documentId: BSONValue, _ event: ChangeEvent<DocumentT>) -> Void)? = nil,
-        errorListener:  ((_ error: DataSynchronizerError, _ documentId: BSONValue?) -> Void)? = nil) {
-        self.proxy.configure(conflictHandler: conflictHandler,
-                             changeEventDelegate: changeEventDelegate,
-                             errorListener: errorListener)
+        errorListener:  ((_ error: DataSynchronizerError, _ documentId: BSONValue?) -> Void)? = nil,
+        _ completionHandler: ((StitchResult<Void>) -> Void)) {
+        queue.async {
+            self.proxy.configure(conflictHandler: conflictHandler,
+                                 changeEventDelegate: changeEventDelegate,
+                                 errorListener: errorListener)
+        }
     }
 
     /**
@@ -41,30 +45,57 @@ public class Sync<DocumentT: Codable> {
      - parameter changeEventDelegate: the event listener to invoke when a change event happens for the
      document.
      - parameter errorListener: the error listener to invoke when an irrecoverable error occurs
+     - parameter completionHandler: the handler to execute when configuration is complete
      */
     public func configure<CH: ConflictHandler, CED: ChangeEventDelegate>(
         conflictHandler: CH,
         changeEventDelegate: CED? = nil,
-        errorListener: ErrorListener? = nil) where CH.DocumentT == DocumentT, CED.DocumentT == DocumentT {
-        self.proxy.configure(conflictHandler: conflictHandler,
-                             changeEventDelegate: changeEventDelegate,
-                             errorListener: errorListener)
+        errorListener: ErrorListener? = nil,
+        _ completionHandler: ((StitchResult<Void>) -> Void)
+    ) where CH.DocumentT == DocumentT, CED.DocumentT == DocumentT {
+
+        queue.async {
+            self.proxy.configure(conflictHandler: conflictHandler,
+                                 changeEventDelegate: changeEventDelegate,
+                                 errorListener: errorListener)
+        }
     }
 
     /**
      Requests that the given document _ids be synchronized.
      - parameter ids: the document _ids to synchronize.
+     - parameter completionHandler: the handler to execute when the provided ids are marked as synced. The documents
+                                    will not necessarily exist in the local collection yet, but will get synced
+                                    down in the next background sync pass
      */
-    public func sync(ids: [BSONValue]) throws {
-        try self.proxy.sync(ids: ids)
+    public func sync(ids: [BSONValue], _ completionHandler: @escaping (StitchResult<Void>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(
+                    .success(result: try self.proxy.sync(ids: ids)))
+            } catch {
+                completionHandler(
+                    .failure(error: .clientError(withClientErrorCode: .syncInitializationError(withError: error))))
+            }
+        }
     }
 
     /**
      Stops synchronizing the given document _ids. Any uncommitted writes will be lost.
      - parameter ids: the _ids of the documents to desynchronize.
+     - parameter completionHandler: the handler to execute when the provided ids are no longer marked as synced. The
+                                    documents will be deleted from the local collection, but not the remote collection.
      */
-    public func desync(ids: [BSONValue]) throws {
-        try self.proxy.desync(ids: ids)
+    public func desync(ids: [BSONValue], _ completionHandler: @escaping (StitchResult<Void>) -> Void) {
+        queue.async {
+            do {
+                completionHandler(
+                    .success(result: try self.proxy.desync(ids: ids)))
+            } catch {
+                completionHandler(
+                    .failure(error: .clientError(withClientErrorCode: .syncInitializationError(withError: error))))
+            }
+        }
     }
 
     /**
@@ -72,8 +103,10 @@ public class Sync<DocumentT: Codable> {
      Remove custom AnyBSONValue after: https://jira.mongodb.org/browse/SWIFT-255
      - returns: the set of synchronized document ids in a namespace.
      */
-    public var syncedIds: Set<AnyBSONValue> {
-        return self.proxy.syncedIds
+    public func syncedIds(_ completionHandler: @escaping (StitchResult<Set<AnyBSONValue>>) -> Void) {
+        queue.async {
+            completionHandler(.success(result: self.proxy.syncedIds))
+        }
     }
 
     /**
@@ -82,8 +115,10 @@ public class Sync<DocumentT: Codable> {
 
      - returns: the set of paused document _ids in a namespace
      */
-    public var pausedIds: Set<AnyBSONValue> {
-        return self.proxy.pausedIds
+    public func pausedIds(_ completionHandler: @escaping (StitchResult<Set<AnyBSONValue>>) -> Void) {
+        queue.async {
+            completionHandler(.success(result: self.proxy.pausedIds))
+        }
     }
 
     /**
@@ -95,273 +130,11 @@ public class Sync<DocumentT: Codable> {
      - returns: true if successfully resumed, false if the document
      could not be found or there was an error resuming
      */
-    public func resumeSync(forDocumentId documentId: BSONValue) -> Bool {
-        return self.proxy.resumeSync(forDocumentId: documentId)
-    }
-
-    /**
-     Counts the number of documents in the collection that have been synchronized with the remote.
-
-     - returns: the number of documents in the collection
-     */
-    public func count(_ completionHandler: @escaping (StitchResult<Int>) -> Void) {
+    public func resumeSync(
+        forDocumentId documentId: BSONValue,
+        _ completionHandler: @escaping (StitchResult<Bool>) -> Void) {
         queue.async {
-            do {
-                completionHandler(
-                    .success(result: try self.proxy.count()))
-            } catch {
-                completionHandler(
-                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
-            }
-        }
-    }
-
-    /**
-     Counts the number of documents in the collection that have been synchronized with the remote
-     according to the given options.
-
-     - parameter filter:  the query filter
-     - parameter options: the options describing the count
-     - parameter completionHandler: the callback for the count result
-     - returns: the number of documents in the collection
-     */
-    public func count(filter: Document,
-                      options: SyncCountOptions?,
-                      _ completionHandler: @escaping (StitchResult<Int>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(
-                    .success(result: try self.proxy.count(filter: filter,
-                                                          options: options)))
-            } catch {
-                completionHandler(
-                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
-            }
-        }
-    }
-
-    /**
-     Finds all documents in the collection that have been synchronized with the remote.
-
-     - parameter completionHandler: the callback for the find result
-     - returns: the find iterable interface
-     */
-    public func find(_ completionHandler: @escaping (StitchResult<MongoCursor<DocumentT>>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(
-                    .success(result: try self.proxy.find()))
-            } catch {
-                completionHandler(
-                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
-            }
-        }
-    }
-
-    /**
-     Finds all documents in the collection that have been synchronized with the remote.
-
-     - parameter filter: the query filter for this find op
-     - parameter options: the options for this find op
-     - parameter completionHandler: the callback for the find result
-     - returns: the find iterable interface
-     */
-    public func find(
-        filter: Document,
-        options: SyncFindOptions? = nil,
-        _ completionHandler: @escaping (StitchResult<MongoCursor<DocumentT>>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(
-                    .success(result: try self.proxy.find(filter: filter, options: options)))
-            } catch {
-                completionHandler(
-                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
-            }
-        }
-    }
-
-    /**
-     Finds a document in the collection that has been synchronized with the remote.
-     
-     - parameter filter: the query filter for this find op
-     - parameter options: the options for this find op
-     - parameter completionHandler: the callback for the find result
-     - returns: the document or nil if no such document existss
-     */
-    public func findOne(
-        filter: Document? = nil,
-        options: SyncFindOptions? = nil,
-        _ completionHandler: @escaping (StitchResult<DocumentT?>) -> Void) {
-        queue.async {
-            do {
-                let newFilter: Document!
-                if let filter = filter { newFilter = filter} else {newFilter = Document.init()}
-                completionHandler(
-                    .success(result: try self.proxy.findOne(filter: newFilter, options: options)))
-            } catch {
-                completionHandler(
-                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
-            }
-        }
-    }
-
-    /**
-     Aggregates documents that have been synchronized with the remote
-     according to the specified aggregation pipeline.
-
-     - parameter pipeline: the aggregation pipeline
-     - parameter options: the options for this aggregate op
-     - returns: an iterable containing the result of the aggregation operation
-     */
-    public func aggregate(pipeline: [Document],
-                          options: AggregateOptions?,
-                          _ completionHandler: @escaping (StitchResult<MongoCursor<Document>>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(
-                    .success(result: try self.proxy.aggregate(pipeline: pipeline, options: options)))
-            } catch {
-                completionHandler(
-                    .failure(error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))))
-            }
-        }
-    }
-
-    /**
-     Inserts the provided document. If the document is missing an identifier, the client should
-     generate one. Syncs the newly inserted document against the remote.
-
-     - parameter document: the document to insert
-     - returns: the result of the insert one operation
-     */
-    public func insertOne(document: DocumentT,
-                          _ completionHandler: @escaping (StitchResult<SyncInsertOneResult?>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(.success(result: try self.proxy.insertOne(document: document)))
-            } catch {
-                completionHandler(.failure(
-                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
-                    ))
-            }
-        }
-    }
-
-    /**
-     Inserts one or more documents. Syncs the newly inserted documents against the remote.
-
-     - parameter documents: the documents to insert
-     - returns: the result of the insert many operation
-     */
-    public func insertMany(documents: [DocumentT],
-                           _ completionHandler: @escaping (StitchResult<SyncInsertManyResult?>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(.success(result: try self.proxy.insertMany(documents: documents)))
-            } catch {
-                completionHandler(.failure(
-                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
-                    ))
-            }
-        }
-    }
-
-    /**
-     Removes at most one document from the collection that has been synchronized with the remote
-     that matches the given filter.  If no documents match, the collection is not
-     modified.
-
-     - parameter filter: the query filter to apply the the delete operation
-     - returns: the result of the remove one operation
-     */
-    public func deleteOne(filter: Document,
-                          _ completionHandler: @escaping (StitchResult<SyncDeleteResult?>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(.success(result: try self.proxy.deleteOne(filter: filter)))
-            } catch {
-                completionHandler(.failure(
-                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
-                    ))
-            }
-        }
-    }
-
-    /**
-     Removes all documents from the collection that have been synchronized with the remote
-     that match the given query filter.  If no documents match, the collection is not modified.
-
-     - parameter filter: the query filter to apply the the delete operation
-     - returns: the result of the remove many operation
-     */
-    public func deleteMany(filter: Document,
-                           _ completionHandler: @escaping (StitchResult<SyncDeleteResult?>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(.success(result: try self.proxy.deleteMany(filter: filter)))
-            } catch {
-                completionHandler(.failure(
-                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
-                    ))
-            }
-        }
-    }
-
-    /**
-     Update a single document in the collection that have been synchronized with the remote
-     according to the specified arguments. If the update results in an upsert,
-     the newly upserted document will automatically become synchronized.
-
-     - parameter filter: a document describing the query filter, which may not be null.
-     - parameter update: a document describing the update, which may not be null. The update to
-     apply must include only update operators.
-     - returns: the result of the update one operation
-     */
-    public func updateOne(filter: Document,
-                          update: Document,
-                          options: SyncUpdateOptions?,
-                          _ completionHandler: @escaping (StitchResult<SyncUpdateResult?>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(.success(
-                    result: try self.proxy.updateOne(filter: filter,
-                                                     update: update,
-                                                     options: options)))
-            } catch {
-                completionHandler(.failure(
-                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
-                    ))
-            }
-        }
-    }
-
-    /**
-     Update all documents in the collection that have been synchronized with the remote
-     according to the specified arguments. If the update results in an upsert,
-     the newly upserted document will automatically become synchronized.
-
-     - parameter filter: a document describing the query filter, which may not be null.
-     - parameter update: a document describing the update, which may not be null. The update to
-     apply must include only update operators.
-     - parameter updateOptions: the options to apply to the update operation
-     - returns: the result of the update many operation
-     */
-    public func updateMany(filter: Document,
-                           update: Document,
-                           options: SyncUpdateOptions?,
-                           _ completionHandler: @escaping (StitchResult<SyncUpdateResult?>) -> Void) {
-        queue.async {
-            do {
-                completionHandler(.success(
-                    result: try self.proxy.updateMany(filter: filter,
-                                                      update: update,
-                                                      options: options)))
-            } catch {
-                completionHandler(.failure(
-                    error: .clientError(withClientErrorCode: .mongoDriverError(withError: error))
-                    ))
-            }
+            completionHandler(.success(result: self.proxy.resumeSync(forDocumentId: documentId)))
         }
     }
 }

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/RemoteMongoClientIntTests.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/RemoteMongoClientIntTests.swift
@@ -1399,7 +1399,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         let sync = coll.sync
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
 
         let joiner = CallbackJoiner()
 
@@ -1424,7 +1424,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         let sync = coll.sync
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
 
         let joiner = CallbackJoiner()
 
@@ -1457,7 +1457,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         let sync = coll.sync
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
 
         let joiner = CallbackJoiner()
 
@@ -1496,7 +1496,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         let sync = coll.sync
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
         let joiner = CallbackJoiner()
         sync.count(joiner.capture())
         XCTAssertEqual(0, joiner.value())
@@ -1534,7 +1534,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         let sync = coll.sync
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
 
         let joiner = CallbackJoiner()
 
@@ -1567,7 +1567,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         let sync = coll.sync
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
 
         let joiner = CallbackJoiner()
 
@@ -1604,7 +1604,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         let sync = coll.sync
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
 
         let joiner = CallbackJoiner()
 
@@ -1660,7 +1660,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
         let sync = coll.sync
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
 
         let joiner = CallbackJoiner()
 
@@ -1715,7 +1715,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
 
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
 
         let joiner = CallbackJoiner()
 
@@ -1765,7 +1765,7 @@ class RemoteMongoClientIntTests: BaseStitchIntTestCocoaTouch {
 
         sync.configure(conflictHandler: { _, _, rDoc in rDoc.fullDocument },
                        changeEventDelegate: { _, _ in },
-                       errorListener: { _, _ in })
+                       errorListener: { _, _ in }, { _ in })
 
         let joiner = CallbackJoiner()
 

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/SyncIntTests.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBServiceTests/SyncIntTests.swift
@@ -1412,7 +1412,7 @@ class SyncIntTests: BaseStitchIntTestCocoaTouch {
 
         var docToInsert = ["hello": "world"] as Document
 
-        coll.configure(conflictHandler: failingConflictHandler) { _ in }
+        coll.configure(conflictHandler: failingConflictHandler)
         let insertResult = coll.insertOne(&docToInsert)!
 
         var doc = coll.findOne(["_id": insertResult.insertedId ?? BSONNull()])!

--- a/Darwin/StitchDarwinCoreTestUtils/StitchDarwinCoreTestUtils/BaseStitchIntTestCocoaTouch.swift
+++ b/Darwin/StitchDarwinCoreTestUtils/StitchDarwinCoreTestUtils/BaseStitchIntTestCocoaTouch.swift
@@ -19,8 +19,8 @@ public class TestNetworkMonitor: NetworkMonitor {
     private var delegates = [WeakNetworkStateDelegate]()
 
     public var state: NetworkState = .connected {
-        didSet(newValue) {
-            delegates.forEach { $0.weak?.on(stateChangedFor: newValue) }
+        didSet {
+            delegates.forEach { $0.weak?.on(stateChangedFor: state) }
         }
     }
 


### PR DESCRIPTION
This makes all the previously blocking sync calls async, and I also drive-by'ed the $in optimizaiton (STITCH-2585).

I did not yet do the optimization that sets is stale for a whole namespace rather than per document, so this will still be relatively slow on disconnect/reconnect until that optimization is made.

I've also moved the CRUD operations from `Sync.swift` into a `Sync+CRUD.swift` to keep the files small.