### PR TITLE
STITCH-2743 Update release scripts and README to follow new requirements

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -35,26 +35,26 @@ To avoid getting a lot of linter warnings, make sure the following whitespace se
 
 ### Publishing a New SDK version (MongoDB Internal Contributors Only)
 
-1. Run `contrib/bump_version.bash <patch|minor|major>`. This will 
-   update the version of the SDK in all of the appropriate Podfiles, it will 
-   update the version of the SDK in the root-level README.md so that it refers 
-   to the latest version of the SDK, and it will stage these changes in the 
-   Git repository.
-
-2. Review the changes made by the version bump script, and then commit the 
-   changes with `git commit -m "Release <VERSION>"`, substituting the
-   placeholder with the appropriate package version.
-
-3. Properly tag the release with the correct version number by running
-   `git tag <VERSION>`, substituting the placeholder with the 
-   appropriate package version. Once the tag is created, push the tag to the 
-   upstream remote with `git push upstream <VERSION>`. Depending on 
-   how your local git is configured, you may need to run
-   `git push origin <VERSION>`.
-
-4. If manual changes were made to any Podfile or podspec, run 
+1. If manual changes were made to any Podfile or podspec, run 
    `contrib/lint_pods.sh` to ensure that the pods will be published 
    successfully. This command may take a while (1-2 hours).
+
+2. Run `contrib/bump_version.sh <patch|minor|major> <jira_ticket>`. This will 
+   update the version of the SDK in all of the appropriate Podfiles, it will 
+   update the version of the SDK in the root-level README.md so that it refers 
+   to the latest version of the SDK, and it will open a pull request on Github
+   with these changes.
+
+3. Go to [iOS SDK](https://github.com/mongodb/stitch-ios-sdk/pulls) and 
+   request a reviewer on the pull request (mandatory) before merging and 
+   deleting the release branch.
+
+4. Properly tag the release with the correct version number by running
+   `git tag <VERSION>` on the master branch after merging, substituting the 
+   placeholder with the appropriate package version. Once the tag is created, 
+   push the tag to the upstream remote with `git push upstream <VERSION>`. 
+   Depending on how your local git is configured, you may need to run
+   `git push origin <VERSION>` instead.
 
 5. Ensure that you are registered for CocoaPods Trunk on your local Mac system.
    See https://guides.cocoapods.org/making/getting-setup-with-trunk.html for

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -49,25 +49,18 @@ To avoid getting a lot of linter warnings, make sure the following whitespace se
    request a reviewer on the pull request (mandatory) before merging and 
    deleting the release branch.
 
-4. Properly tag the release with the correct version number by running
-   `git tag <VERSION>` on the master branch after merging, substituting the 
-   placeholder with the appropriate package version. Once the tag is created, 
-   push the tag to the upstream remote with `git push upstream <VERSION>`. 
-   Depending on how your local git is configured, you may need to run
-   `git push origin <VERSION>` instead.
-
-5. Ensure that you are registered for CocoaPods Trunk on your local Mac system.
+4. Ensure that you are registered for CocoaPods Trunk on your local Mac system.
    See https://guides.cocoapods.org/making/getting-setup-with-trunk.html for
    more context on this step.
 
-6. Run `contrib/publish_pods.sh`. This publishes all of the pods for the 
+5. Run `contrib/publish_pods.sh`. This publishes all of the pods for the 
    project. This command may take a while (1-2 hours).
 
-7. Close XCode if it is already open, and run `contrib/generate_docs.sh`. This
+6. Close XCode if it is already open, and run `contrib/generate_docs.sh`. This
    generates the Jazzy documentation for the project, and publishes it to the 
    appropriate AWS S3 bucket.
 
-8. Publish a release for the new SDK version on the GitHub repository and 
+7. Publish a release for the new SDK version on the GitHub repository and 
    include relevant release notes. See
    https://help.github.com/en/articles/creating-releases for context, and 
    follow the general format of our previous releases.

--- a/contrib/bump_version.sh
+++ b/contrib/bump_version.sh
@@ -8,7 +8,7 @@ cd $DIR
 cd ..
 
 # Ensure that 'hub' is installed
-which hub
+which hub || (echo "hub is not installed. Please see contrib/README.md for more info" && exit 1)
 
 # Ensure that there are no working changes that will accidentally get committed.
 STATUS="$(git status -s)"

--- a/contrib/bump_version.sh
+++ b/contrib/bump_version.sh
@@ -66,7 +66,7 @@ echo "Bumping $LAST_VERSION to $NEW_VERSION ($BUMP_TYPE)"
 # Create the branch for the release PR
 RELEASE_BRANCH="Release-$JIRA_TICKET"
 git checkout -b $RELEASE_BRANCH
-git push -u origin $RELEASE_BRANCH
+git push -u upstream $RELEASE_BRANCH
 
 # Update all of the podspecs
 echo "Updating podspecs"
@@ -107,7 +107,7 @@ sed -i "" -E "$PODSPEC_SED_REGEX" README.md
 git add README.md
 
 git commit -m "$JIRA_TICKET Release $NEW_VERSION"
-git push -u origin $RELEASE_BRANCH
+git push -u upstream $RELEASE_BRANCH
 
 echo "creating pull request in github..."
 hub pull-request -m "$JIRA_TICKET: Release $NEW_VERSION" --base mongodb:master --head mongodb:$RELEASE_BRANCH

--- a/contrib/bump_version.sh
+++ b/contrib/bump_version.sh
@@ -64,8 +64,9 @@ NEW_VERSION=$NEW_VERSION_MAJOR.$NEW_VERSION_MINOR.$NEW_VERSION_PATCH
 echo "Bumping $LAST_VERSION to $NEW_VERSION ($BUMP_TYPE)"
 
 # Create the branch for the release PR
-git checkout -b "Release-$JIRA_TICKET"
-git push -u origin "Release-$JIRA_TICKET"
+RELEASE_BRANCH="Release-$JIRA_TICKET"
+git checkout -b $RELEASE_BRANCH
+git push -u origin $RELEASE_BRANCH
 
 # Update all of the podspecs
 echo "Updating podspecs"
@@ -106,6 +107,7 @@ sed -i "" -E "$PODSPEC_SED_REGEX" README.md
 git add README.md
 
 git commit -m "$JIRA_TICKET Release $NEW_VERSION"
+git push -u origin $RELEASE_BRANCH
 
 echo "creating pull request in github..."
-hub pull-request -m "$JIRA_TICKET: Release $NEW_VERSION" --base mongodb:master --head mongodb:"Release-$JIRA_TICKET"
+hub pull-request -m "$JIRA_TICKET: Release $NEW_VERSION" --base mongodb:master --head mongodb:$RELEASE_BRANCH

--- a/contrib/publish_pods.sh
+++ b/contrib/publish_pods.sh
@@ -7,6 +7,14 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 cd ..
 
+
+# Verify that we are on the master branch
+git status | head -n 1 | grep master || (echo "must be on master branch" && exit 1)
+
+CURRENT_VERSION=`cat StitchSDK.podspec | grep "spec.version" | head -1 | cut -d \" -f2`
+git tag CURRENT_VERSION
+git push upstream CURRENT_VERSION
+
 # Declare the list of pods to be linted
 declare -a PODSPECS=(
 	"Core/StitchCoreSDK/StitchCoreSDK.podspec"


### PR DESCRIPTION
Just like the JS and Android PRs, this updates the `bump_version` script to open a PR with the necessary changes for a release to be made. I also updated the README to explain how the process goes after that.