### PR TITLE
DOCSP-4377 Auth flow

### DIFF
--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Anonymous/AnonymousCredential.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Anonymous/AnonymousCredential.swift
@@ -1,8 +1,11 @@
 import MongoSwift
 
 /**
- * A credential which can be used to log in as a Stitch user
- * using the anonymous authentication provider.
+ * The `AnonymousCredential` is a `StitchCredential` that can be used to log in
+ * using the [Anonymous Authentication Provider](https://docs.mongodb.com/stitch/authentication/anonymous/).
+ *
+ * - SeeAlso:
+ * `StitchAuth`
  */
 public struct AnonymousCredential: StitchCredential {
     // MARK: Initializer

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Facebook/FacebookCredential.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Facebook/FacebookCredential.swift
@@ -1,8 +1,11 @@
 import MongoSwift
 
 /**
- * A credential which can be used to log in as a Stitch user
- * using the Facebook authentication provider.
+ * The `FacebookCredential` is a `StitchCredential` that can be used log in
+ * using the [Facebook Authentication Provider](https://docs.mongodb.com/stitch/authentication/facebook/).
+ *
+ * - SeeAlso:
+ * `StitchAuth`
  */
 public struct FacebookCredential: StitchCredential {
     // MARK: Initializer

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Google/GoogleCredential.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Google/GoogleCredential.swift
@@ -1,14 +1,17 @@
 import MongoSwift
 
 /**
- * A credential which can be used to log in as a Stitch user
- * using the Google authentication provider.
+ * The `GoogleCredential` is a `StitchCredential` that is used to log in
+ * using the [Google Authentication Provider](https://docs.mongodb.com/stitch/authentication/google/).
+ *
+ * - SeeAlso:
+ * `StitchAuth`
  */
 public struct GoogleCredential: StitchCredential {
     // MARK: Initializer
 
     /**
-     * Initializes this credential with the name of the provider, and a Google OAuth2 authentication code.
+     * Initializes this credential with the name of the provider and a Google OAuth2 authentication code.
      */
     public init(withProviderName providerName: String = providerType.name,
                 withAuthCode authCode: String) {

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/UserPassword/UserPasswordCredential.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/UserPassword/UserPasswordCredential.swift
@@ -1,8 +1,11 @@
 import MongoSwift
 
 /**
- * A credential which can be used to log in as a Stitch user
- * using the username/password authentication provider.
+ * The `UserPasswordCredential` is a `StitchCredential` that is used to log in
+ * using the [Username/Password Authentication Provider](https://docs.mongodb.com/stitch/authentication/userpass/).
+ *
+ * - SeeAlso:
+ * `StitchAuth`
  */
 public struct UserPasswordCredential: StitchCredential {
     // MARK: Initializer

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/StitchCredential.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/StitchCredential.swift
@@ -1,18 +1,28 @@
 import MongoSwift
 
 /**
- * A credential which can be used to log in as a Stitch user. There is an implementation for each authentication
- * provider available in MongoDB Stitch. These implementations can be generated using an authentication provider
- * client.
+ * A `StitchCredential` can be used to log in.
+ * 
+ * There is an implementation for each available
+ * [Authentication Provider](https://docs.mongodb.com/stitch/authentication/providers/).
+ * These implementations can be generated using an `AuthProviderClientFactory`.
+ *
+ * To log in, pass a credential implementation for the provider you want to use
+ * to `StitchAuth`'s `loginWithCredential` method.
+ *
+ * - SeeAlso:
+ * `StitchAuth`
  */
 public protocol StitchCredential {
     /**
-     * The name of the authentication provider that this credential will be used to authenticate with.
+     * The name of the associated
+     * [Authentication Provider](https://docs.mongodb.com/stitch/authentication/providers/).
      */
     var providerName: String { get }
 
     /**
-     * The type of the authentication provider that this credential will be used to authenticate with.
+     * The type of the associated 
+     * [Authentication Provider](https://docs.mongodb.com/stitch/authentication/providers/).
      */
     static var providerType: StitchProviderType { get }
 

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/StitchUserIdentity.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/StitchUserIdentity.swift
@@ -1,9 +1,15 @@
 /**
- * A protocol representing an identity that a Stitch user is linked to and can use to sign into their account.
+ * The `StitchUserIdentity` represents an identity that a `StitchUser` is linked to
+ * and can use to log in to their account.
+ *
+ * - SeeAlso:
+ * `StitchAuth`,
+ * `StitchUser`,
+ * [Stitch Users](https://docs.mongodb.com/stitch/users/)
  */
 public protocol StitchUserIdentity: Codable {
     /**
-     * The id of this identity in MongoDB Stitch
+     * The id of this identity in MongoDB Stitch.
      *
      * - important: This is **not** the id of the Stitch user.
      */

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/StitchUserProfile.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/StitchUserProfile.swift
@@ -23,7 +23,11 @@ public protocol APIStitchUserProfile {
 }
 
 /**
- * A protocol containing the fields returned by the Stitch client API in the `data` field of a user profile request.
+ * The `ExtendedStitchUserProfile` contains the fields returned by the Stitch client API
+ * in the `data` field of a user profile request.
+ *
+ * - SeeAlso:
+ * `StitchUser`, `StitchAuth`
  */
 public protocol ExtendedStitchUserProfile {
     /**
@@ -73,12 +77,23 @@ public protocol ExtendedStitchUserProfile {
 }
 
 /**
- * The set of properties that describe a MongoDB Stitch user. See the documentation for `ExtendedStitchUserProfile` to
- * see the additional fields available on this type.
+ * The StitchUserProfile describes a `StitchUser`.
+ *
+ * Every `StitchUser` has a `StitchUserProfile` member.
+ * 
+ * See `ExtendedStitchUserProfile` for additional fields available on this type.
+ *
+ * - SeeAlso:
+ * `ExtendedStitchUserProfile`,
+ * `StitchUser`,
+ * `StitchAuth`
  */
 public protocol StitchUserProfile: ExtendedStitchUserProfile {
     /**
-     * A string describing the type of this user. (Either `server` or `normal`)
+     * A string describing the type of this user, either `"server"` or `"normal"`.
+     *
+     * `"server"` users are users authenticated via a server API key generated 
+     * in the MongoDB Stitch admin console. All other users are `"normal"` users.
      */
     var userType: String { get }
 

--- a/Darwin/StitchCore/StitchCore/Core/Auth/StitchAuth.swift
+++ b/Darwin/StitchCore/StitchCore/Core/Auth/StitchAuth.swift
@@ -1,8 +1,20 @@
 import StitchCoreSDK
 
 /**
- * A set of methods for retrieving or modifying the authentication state of a `StitchAppClient`.
- * An implementation can be instantiated with a `StitchAppClient` instance.
+ * The `StitchAuth` provides methods for retrieving or modifying the authentication
+ * state of a `StitchAppClient`.
+ *
+ * Each `StitchAppClient` has an instance of StitchAuth.
+ *
+ * Information about the logged-in `StitchUser` is available in the `currentUser` property.
+ *
+ * To watch for auth events, add a `StitchAuthDelegate`.
+ *
+ * - SeeAlso:
+ * `StitchAppClient`,
+ * `StitchUser`,
+ * `StitchAuthDelegate`
+ * 
  */
 public protocol StitchAuth {
 

--- a/Darwin/StitchCore/StitchCore/Core/Auth/StitchAuthDelegate.swift
+++ b/Darwin/StitchCore/StitchCore/Core/Auth/StitchAuthDelegate.swift
@@ -1,9 +1,8 @@
 import StitchCoreSDK
 
 /**
-  A protocol to be inherited by classes that need to take action whenever a particular `StitchAppClient` performs an
-  authentication event. An instance of a `StitchAuthDelegate` must be registered with a `StitchAuth` for this to work
-  correctly.
+  `StitchAuthDelegate` is a protocol to be inherited when you need to take action on authentication events.
+  An instance of a `StitchAuthDelegate` must be added to a `StitchAuth`.
 
   - Note:
      This protocol uses an extension to provide default implementations. This is for your convenience, so you do not
@@ -14,13 +13,19 @@ import StitchCoreSDK
      for more context and potential workarounds, or open an issue in our GitHub repository.
 
     - Tag: StitchAuthDelegate
+
+  - SeeAlso:
+  `StitchAuth`,
+  [Working with Multiple User Accounts](https://docs.mongodb.com/stitch/authentication/implement-multi-user/)
  */
 public protocol StitchAuthDelegate: class {
     /**
-     * A method to be called whenever a `StitchAppClient` performs an authentication event.
-     * Note, when this method is invoked by a `StitchAuth` for which this delegate is registered,
-     * the invocation will be dispatched to a non-main dispatch queue, so be sure to dispatch any
-     * UI operations back to the main `DispatchQueue`.
+     * Called whenever a `StitchAppClient` performs an authentication event.
+     *
+     * - Note: 
+     *   When this method is invoked by a `StitchAuth` for which this delegate is registered,
+     *   the invocation will be dispatched to a non-main dispatch queue, so be sure to dispatch any
+     *   UI operations back to the main `DispatchQueue`.
      *
      * - parameters:
      *    - fromAuth: The `StitchAuth` object that caused the authentication event.

--- a/Darwin/StitchCore/StitchCore/Core/Auth/StitchUser.swift
+++ b/Darwin/StitchCore/StitchCore/Core/Auth/StitchUser.swift
@@ -2,8 +2,15 @@ import Foundation
 import StitchCoreSDK
 
 /**
- * A set of methods and properties that represent a user that a `StitchAppClient` is currently authenticated as.
- * Can be retrieved from a `StitchAuth` or from the `StitchResult` of certain methods.
+ * The `StitchUser` represents the the user who is logged in to the `StitchAppClient`.
+ * 
+ * You can retrieve an instance from `StitchAuth` or from the `StitchResult` of certain methods.
+ *
+ * You will find information about the user such as name and email address in the `StitchUserProfile`
+ * property `profile`.
+ * 
+ * - SeeAlso:
+ * `StitchAuth`
  */
 public protocol StitchUser: CoreStitchUser {
     // MARK: Properties
@@ -14,22 +21,27 @@ public protocol StitchUser: CoreStitchUser {
     var id: String { get }
 
     /**
-     * The type of authentication provider used to log in as this user.
+     * The type of [Authentication Provider](https://docs.mongodb.com/stitch/authentication/providers/)
+     * used to log in as this user.
      */
     var loggedInProviderType: StitchProviderType { get }
 
     /**
-     * The name of the authentication provider used to log in as this user.
+     * The name of the [Authentication Provider](https://docs.mongodb.com/stitch/authentication/providers/)
+     * used to log in as this user.
      */
     var loggedInProviderName: String { get }
 
     /**
-     * A string describing the type of this user. (Either `server` or `normal`)
+     * A string describing the type of this user, either `"normal"` or `"server"`.
+     *
+     * `"server"` users are users authenticated via a server API key generated 
+     * in the MongoDB Stitch admin console. All other users are `"normal"` users.
      */
     var userType: String { get }
 
     /**
-     * A `StitchUserProfile` object describing this user.
+     * A `StitchUserProfile` describing this user.
      */
     var profile: StitchUserProfile { get }
 
@@ -40,13 +52,13 @@ public protocol StitchUser: CoreStitchUser {
     var identities: [StitchUserIdentity] { get }
 
     /**
-     * If this user is currently logged in
+     * If this user is currently logged in.
      */
     var isLoggedIn: Bool { get }
 
     /**
-     * The last time this user was logged into, logged out of, switched to, or switched from
-     * This is stored as the TimeInterval (seconds) since the Unix Epoch
+     * The last time this user was logged in, logged out, switched to, or switched from.
+     * This is stored as the `TimeInterval` (seconds) since the Unix Epoch.
      */
     var lastAuthActivity: TimeInterval { get }
 
@@ -56,8 +68,9 @@ public protocol StitchUser: CoreStitchUser {
     // swiftlint:disable line_length
     /**
      * Links the currently authenticated `StitchUser` with a new identity, where the identity is defined by the credential
-     * specified as a parameter. This will only be successful if this `StitchUser` is the currently authenticated
-     * `StitchUser` for the client from which it was created.
+     * specified as a parameter.
+     * 
+     * This will only be successful if this `StitchUser` is the currently authenticated `StitchUser`.
      *
      * - parameters:
      *     - withCredential: The `StitchCore.StitchCredential` used to link the user to a new

--- a/Darwin/StitchCore/StitchCore/Core/Stitch.swift
+++ b/Darwin/StitchCore/StitchCore/Core/Stitch.swift
@@ -2,8 +2,9 @@ import Foundation
 import StitchCoreSDK
 
 /**
- * Singleton class with static utility functions for initializing the MongoDB Stitch iOS SDK,
- * and for retrieving a `StitchAppClient`.
+ * `Stitch` is the singleton class with static utility functions for initializing the SDK.
+ * 
+ * Use it to initialize and retrieve a `StitchAppClient` for your Stitch app.
  */
 public class Stitch {
 

--- a/Darwin/StitchCore/StitchCore/Core/StitchAppClient.swift
+++ b/Darwin/StitchCore/StitchCore/Core/StitchAppClient.swift
@@ -3,17 +3,32 @@ import StitchCoreSDK
 import Foundation
 
 /**
- * The fundamental set of methods for communicating with a MongoDB Stitch application.
- * Contains methods for executing Stitch functions and retrieving clients for Stitch services,
- * contains a `StitchAuth` object to manage the authentication state of the client, and contains a
- * `StitchPush` object to register the current user for push notifications. An implementation can be instantiated using
- * the `Stitch` utility class.
+ * The `StitchAppClient` has the fundamental set of methods for communicating with a MongoDB
+ * Stitch application backend.
+ *
+ * An implementation can be initialized or retrieved using the `Stitch` utility class.
+ *
+ * This protocol provides access to the `StitchAuth` for login and authentication.
+ *
+ * Using `serviceClient`, you can retrieve services, including the `RemoteMongoClient` for reading
+ * and writing on the database.
+ *
+ * You can also use it to execute Stitch [Functions](https://docs.mongodb.com/stitch/functions/).
+ * 
+ * Finally, its `StitchPush` object can register the current user for push notifications.
+ *
+ * - SeeAlso:
+ * `Stitch`,
+ * `StitchAuth`,
+ * `RemoteMongoClient`,
+ * `StitchPush`,
+ * [Functions](https://docs.mongodb.com/stitch/functions/)
  */
 public protocol StitchAppClient {
     // MARK: Authentication
 
     /**
-     * The StitchAuth object representing the authentication state of this client. Includes methods for logging in
+     * The `StitchAuth` object representing the authentication state of this client. Includes methods for logging in
      * and logging out.
      *
      * - important: Authentication state can be persisted beyond the lifetime of an application.

--- a/Darwin/StitchCore/StitchCore/Core/StitchResult.swift
+++ b/Darwin/StitchCore/StitchCore/Core/StitchResult.swift
@@ -2,9 +2,11 @@ import Foundation
 import StitchCoreSDK
 
 /**
- * `StitchResult` holds the result to an asynchronous operation performed against the Stitch server. When the operation
- * was completed successfully, it holds the result of the operation. When the operation fails, it contains a
- * `StitchError` object describing the reason for the failure.
+ * `StitchResult` holds the result to an asynchronous operation performed against the Stitch server.
+ * 
+ * When an operation completes successfully, the `StitchResult` holds the result of the operation.
+ * When the operation fails, the `StitchResult` contains a `StitchError` object describing
+ * the reason for the failure.
  */
 public enum StitchResult<T> {
     /**

--- a/contrib/stage_docs.sh
+++ b/contrib/stage_docs.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -ex
+
+pushd "$(dirname "$0")"
+
+USER=`whoami`
+
+./generate_docs.sh
+
+if ! which aws; then
+    echo "aws CLI not found. see: https://docs.aws.amazon.com/cli/latest/userguide/installing.html"
+    popd > /dev/null
+    exit 1
+fi
+
+BRANCH_NAME=`git branch | grep -e "^*" | cut -d' ' -f 2`
+
+USER_BRANCH="${USER}/${BRANCH_NAME}"
+
+aws s3 --profile 10gen-noc cp ../docs s3://docs-mongodb-org-staging/stitch/"$USER_BRANCH"/sdk/swift/ --recursive --acl public-read
+
+echo
+echo "Staged URL:"
+echo "  https://docs-mongodbcom-staging.corp.mongodb.com/stitch/"$USER_BRANCH"/sdk/swift/index.html"
+
+popd > /dev/null


### PR DESCRIPTION
This adds See Also links and more content to the entities for the auth flow.

"See Also" is a bit weird on Jazzy. I tried using a bulleted list, but it ended up printing "SeeAlso:" twice... so I went with commas.

Staged:
https://docs-mongodbcom-staging.corp.mongodb.com/stitch/bush/docsp-4377-auth/sdk/swift/index.html
