### PR TITLE
DOCSP-4379 Documentation improvements around CRUD flow

### DIFF
--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoClient.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoClient.swift
@@ -18,15 +18,27 @@ private final class RemoteMongoClientFactory: NamedThrowingServiceClientFactory 
 }
 
 /**
- * Global factory const which can be used to create a `RemoteMongoClient` with a `StitchAppClient`. Pass into
- * `StitchAppClient.serviceClient(fromFactory:withName)` to get a `RemoteMongoClient.
+ * The `remoteMongoClientFactory` can be used to create a `RemoteMongoClient` with a `StitchAppClient`.
+ * 
+ * Use this with `StitchAppClient.serviceClient(fromFactory:withName)` to get a `RemoteMongoClient`.
  */
 public let remoteMongoClientFactory =
     AnyNamedThrowingServiceClientFactory<RemoteMongoClient>(factory: RemoteMongoClientFactory())
 
 /**
- * A class which can be used to get database and collection objects which can be used to interact with MongoDB data via
- * the Stitch MongoDB service.
+ * The `RemoteMongoClient` enables reading and writing on a MongoDB database via the Stitch MongoDB service.
+ *
+ * You can create one by using `remoteMongoClientFactory` with `StitchAppClient`'s
+ * `serviceClient(fromFactory:withName)` method.
+ *
+ * It provides access to instances of `RemoteMongoDatabase`, which in turn provide access to specific
+ * `RemoteMongoCollection`s that hold your data.
+ *
+ * - Note:
+ * Before you can read or write data, a user must log in. See `StitchAuth`.
+ *
+ * - SeeAlso:
+ * `StitchAppClient`, `RemoteMongoDatabase`, `RemoteMongoCollection`
  */
 public class RemoteMongoClient {
     private let dispatcher: OperationDispatcher
@@ -39,7 +51,7 @@ public class RemoteMongoClient {
     }
 
     /**
-     * Gets a `CoreRemoteMongoDatabase` instance for the given database name.
+     * Gets a `RemoteMongoDatabase` instance for the given database name.
      *
      * - parameter name: the name of the database to retrieve
      */

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoCursor.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoCursor.swift
@@ -3,8 +3,15 @@ import StitchCore
 import StitchCoreRemoteMongoDBService
 
 /**
- * A cursor of documents which can be traversed asynchronously. A `RemoteMongoCursor` can be the result of a `find` or
- * `aggregate` operation.
+ * `RemoteMongoCursor` allows asynchronous traversal of the result of a `find` or
+ * `aggregate` operation on a `RemoteMongoCollection`.
+ * 
+ *  You can obtain an instance of the cursor by calling `RemoteMongoReadOperation`'s
+ * `iterator(completionHandler:)` method. `RemoteMongoReadOperation` is the result
+ * of a find or aggregate operation on a `RemoteMongoCollection`.
+ *
+ * - SeeAlso:
+ * `RemoteMongoCollection`, `RemoteMongoReadOperation`
  */
 public class RemoteMongoCursor<T: Codable> {
     private let dispatcher: OperationDispatcher

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoDatabase.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoDatabase.swift
@@ -4,7 +4,18 @@ import StitchCore
 import StitchCoreRemoteMongoDBService
 
 /**
- * A class representing a MongoDB database accesible via the Stitch MongoDB service.
+ * The `RemoteMongoDatabase` represents a MongoDB database, which holds a group
+ * of collections that contain your data.
+ *
+ * It can be retrieved from the `RemoteMongoClient`.
+ *
+ * Use it to get `RemoteMongoCollection`s for reading and writing data.
+ * 
+ * - Note:
+ * Before you can read or write data, a user must log in. See `StitchAuth`.
+ * 
+ * - SeeAlso:
+ * `RemoteMongoClient`, `RemoteMongoCollection`
  */
 public class RemoteMongoDatabase {
     private let dispatcher: OperationDispatcher
@@ -24,7 +35,7 @@ public class RemoteMongoDatabase {
     }
 
     /**
-     * Gets a collection.
+     * Gets a `RemoteMongoCollection`.
      *
      * - parameter name: the name of the collection to return
      * - returns: the collection
@@ -37,7 +48,7 @@ public class RemoteMongoDatabase {
     }
 
     /**
-     * Gets a collection with a specific default document type.
+     * Gets a `RemoteMongoCollection` with a specific default document type.
      *
      * - parameter name: the name of the collection to return
      * - parameter withCollectionType: the default class to cast any documents returned from the database into.

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoReadOperation.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/RemoteMongoReadOperation.swift
@@ -4,8 +4,13 @@ import StitchCore
 import StitchCoreRemoteMongoDBService
 
 /**
- * Represents a `find` or `aggregate` operation against a MongoDB collection. Use the methods in this class to execute
- * the operation and retrieve the results.
+ * `RemoteMongoReadOperation` represents a `find` or `aggregate` operation 
+ * on a `RemoteMongoCollection`.
+ * 
+ * The methods in this class execute the operation and retrieve the results.
+ *
+ * - SeeAlso:
+ * `RemoteMongoCollection`
  */
 public class RemoteMongoReadOperation<T: Codable> {
     private let proxy: CoreRemoteMongoReadOperation<T>
@@ -47,7 +52,7 @@ public class RemoteMongoReadOperation<T: Codable> {
     }
 
     /**
-     * Executes the operation and returns the result as an array. Deprecated in favor of toArray.
+     * Executes the operation and returns the result as an array. Deprecated in favor of `toArray(completionHandler:)`.
      *
      * - parameters:
      *   - completionHandler: The completion handler to call when the operation is completed or if the operation fails.
@@ -60,7 +65,7 @@ public class RemoteMongoReadOperation<T: Codable> {
     }
 
     /**
-     * Executes the operation and returns a cursor to its resulting documents.
+     * Executes the operation and returns a `RemoteMongoCursor` to its resulting documents.
      *
      * - parameters:
      *   - completionHandler: The completion handler to call when the operation is completed or if the operation fails.

--- a/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
+++ b/Darwin/Services/StitchRemoteMongoDBService/StitchRemoteMongoDBService/Sync.swift
@@ -4,7 +4,13 @@ import StitchCore
 import StitchCoreRemoteMongoDBService
 
 /**
- * A set of synchronization related operations for a collection.
+ * `Sync` is a set of synchronization-related operations for a `RemoteMongoCollection`.
+ *
+ * Using Sync, you can synchronize local and remote data.
+ *
+ * - SeeAlso:
+ * [Build a Mobile App with Sync](https://docs.mongodb.com/stitch/mongodb/mobile/build-sync/),
+ * RemoteMongoCollection
  */
 public class Sync<DocumentT: Codable> {
     internal let proxy: CoreSync<DocumentT>

--- a/Darwin/StitchCore/StitchCore/Core/StitchAppClient.swift
+++ b/Darwin/StitchCore/StitchCore/Core/StitchAppClient.swift
@@ -11,7 +11,8 @@ import Foundation
  * This protocol provides access to the `StitchAuth` for login and authentication.
  *
  * Using `serviceClient`, you can retrieve services, including the `RemoteMongoClient` for reading
- * and writing on the database.
+ * and writing on the database. To create a `RemoteMongoClient`, pass `remoteMongoClientFactory`
+ * into `serviceClient(fromFactory:withName)`.
  *
  * You can also use it to execute Stitch [Functions](https://docs.mongodb.com/stitch/functions/).
  * 


### PR DESCRIPTION
This adds connecting links and content in the CRUD-related entities.

Start at StitchAppClient and navigate down to RemoteMongoCursor,
RemoteMongoReadOperation, and Sync.

Staged:
https://docs-mongodbcom-staging.corp.mongodb.com/stitch/bush/docsp-4379-crud/sdk/swift/index.html
