### PR TITLE
STITCH-3632 add client sdk credentials for Apple sign in

### DIFF
--- a/Core/Services/StitchCoreRemoteMongoDBService/StitchCoreRemoteMongoDBService.xcodeproj/project.pbxproj
+++ b/Core/Services/StitchCoreRemoteMongoDBService/StitchCoreRemoteMongoDBService.xcodeproj/project.pbxproj
@@ -483,6 +483,11 @@
 				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/bson.framework.dSYM",
 				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/mongoc.framework",
 				"${PODS_ROOT}/mongo-embedded-c-driver/iPhoneOS/Frameworks/mongoc.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/MongoMobile/MongoMobile.framework",
+				"${PODS_ROOT}/mongo_embedded/iPhoneOS/Frameworks/mongo_embedded.framework",
+				"${PODS_ROOT}/mongo_embedded/iPhoneOS/Frameworks/mongo_embedded.framework.dSYM",
+				"${PODS_ROOT}/mongoc_embedded/iPhoneOS/Frameworks/mongoc_embedded.framework",
+				"${PODS_ROOT}/mongoc_embedded/iPhoneOS/Frameworks/mongoc_embedded.framework.dSYM",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -491,6 +496,11 @@
 				"${DWARF_DSYM_FOLDER_PATH}/bson.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mongoc.framework",
 				"${DWARF_DSYM_FOLDER_PATH}/mongoc.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MongoMobile.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mongo_embedded.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/mongo_embedded.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mongoc_embedded.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/mongoc_embedded.framework.dSYM",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Core/StitchCoreAdminClient/Sources/StitchCoreAdminClient/AuthProviders/ProviderConfig.swift
+++ b/Core/StitchCoreAdminClient/Sources/StitchCoreAdminClient/AuthProviders/ProviderConfig.swift
@@ -7,6 +7,11 @@ private enum ConfigKeys: String, CodingKey {
 }
 
 /// Keys for the `custom-token` provider configuration
+private enum AppleCodingKeys: String, CodingKey {
+    case clientId, clientSecret
+}
+
+/// Keys for the `custom-token` provider configuration
 private enum CustomTokenCodingKeys: String, CodingKey {
     case signingKey
 }
@@ -42,6 +47,8 @@ public enum ProviderConfigs: Encodable {
     }
 
     case anon
+    case apple(clientId: String, clientSecret: String)
+
     /// - parameter emailConfirmationURL: url to redirect user to for email confirmation
     /// - parameter resetPasswordURL: url to redirect user to for password reset
     /// - parameter confirmEmailSubject: subject of the email to confirm a new user
@@ -67,6 +74,7 @@ public enum ProviderConfigs: Encodable {
         case .userpass: return .userPassword
         case .custom: return .custom
         case .customFunction: return .function
+        case .apple: return .apple
         }
     }
 
@@ -75,6 +83,11 @@ public enum ProviderConfigs: Encodable {
         try container.encode(self.type.name, forKey: .type)
         switch self {
         case .anon: break
+        case .apple(let clientId, let clientSecret):
+            var configContainer = container.nestedContainer(keyedBy: AppleCodingKeys.self,
+                                                            forKey: .config)
+            try configContainer.encode(clientId, forKey: .clientId)
+            try configContainer.encode(clientSecret, forKey: .clientSecret)
         case .userpass(let emailConfirmationURL,
                        let resetPasswordURL,
                        let confirmEmailSubject,

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Apple/AppleAuthProvider.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Apple/AppleAuthProvider.swift
@@ -1,6 +1,6 @@
 /**
  * :nodoc:
- * The Google authentication provider.
+ * The Apple authentication provider.
  */
 public final class AppleAuthProvider {
     private init() {}

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Apple/AppleAuthProvider.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Apple/AppleAuthProvider.swift
@@ -1,0 +1,10 @@
+/**
+ * :nodoc:
+ * The Google authentication provider.
+ */
+public final class AppleAuthProvider {
+    private init() {}
+
+    public static let type = "oauth2-apple"
+    public static let defaultName = "oauth2-apple"
+}

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Apple/AppleCredential.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Apple/AppleCredential.swift
@@ -1,7 +1,7 @@
 import MongoSwift
 
 /**
- * The `Apple` is a `StitchCredential` that is used to log in
+ * The `AppleCredential` is a `StitchCredential` that is used to log in
  * using the [Apple Authentication Provider](https://docs.mongodb.com/stitch/authentication/apple/).
  *
  * - SeeAlso:
@@ -11,12 +11,12 @@ public struct AppleCredential: StitchCredential {
     // MARK: Initializer
 
     /**
-     * Initializes this credential with the name of the provider and a Google OAuth2 authentication code.
+     * Initializes this credential with the name of the provider and a Apple OAuth2 identity token.
      */
     public init(withProviderName providerName: String = providerType.name,
-                withAuthCode authCode: String) {
+                identityToken: Data) {
         self.providerName = providerName
-        self.authCode = authCode
+        self.identityToken = String(data: identityToken, encoding: .utf8)!
     }
 
     // MARK: Properties
@@ -35,7 +35,7 @@ public struct AppleCredential: StitchCredential {
      * The contents of this credential as they will be passed to the Stitch server.
      */
     public var material: Document {
-        return ["authCode": authCode]
+        return ["id_token": identityToken]
     }
 
     /**
@@ -45,7 +45,7 @@ public struct AppleCredential: StitchCredential {
         ProviderCapabilities.init(reusesExistingSession: false)
 
     /**
-     * The Google OAuth2 authentication code contained within this credential.
+     * The Apple OAuth2 identity token contained within this credential.
      */
-    private let authCode: String
+    private let identityToken: String
 }

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Apple/AppleCredential.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/Apple/AppleCredential.swift
@@ -1,0 +1,51 @@
+import MongoSwift
+
+/**
+ * The `Apple` is a `StitchCredential` that is used to log in
+ * using the [Apple Authentication Provider](https://docs.mongodb.com/stitch/authentication/apple/).
+ *
+ * - SeeAlso:
+ * `StitchAuth`
+ */
+public struct AppleCredential: StitchCredential {
+    // MARK: Initializer
+
+    /**
+     * Initializes this credential with the name of the provider and a Google OAuth2 authentication code.
+     */
+    public init(withProviderName providerName: String = providerType.name,
+                withAuthCode authCode: String) {
+        self.providerName = providerName
+        self.authCode = authCode
+    }
+
+    // MARK: Properties
+
+    /**
+     * The name of the provider for this credential.
+     */
+    public var providerName: String
+
+    /**
+     * The type of the provider for this credential.
+     */
+    public static let providerType: StitchProviderType = .apple
+
+    /**
+     * The contents of this credential as they will be passed to the Stitch server.
+     */
+    public var material: Document {
+        return ["authCode": authCode]
+    }
+
+    /**
+     * The behavior of this credential when logging in.
+     */
+    public var providerCapabilities: ProviderCapabilities =
+        ProviderCapabilities.init(reusesExistingSession: false)
+
+    /**
+     * The Google OAuth2 authentication code contained within this credential.
+     */
+    private let authCode: String
+}

--- a/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/StitchProviderType.swift
+++ b/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/StitchProviderType.swift
@@ -13,6 +13,11 @@ public enum StitchProviderType: String, Codable {
     case anonymous
 
     /**
+     * The Apple OAuth2 authentication provider.
+     */
+    case apple
+
+    /**
      * The custom authentication provider.
      */
     case custom
@@ -54,6 +59,8 @@ public enum StitchProviderType: String, Codable {
         switch self {
         case .anonymous:
             return "anon-user"
+        case .apple:
+            return "oauth2-apple"
         case .custom:
             return "custom-token"
         case .facebook:

--- a/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
+++ b/Core/StitchCoreSDK/StitchCoreSDK.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		498062F82185C53A00E2A3A2 /* MockUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 498062F72185C53A00E2A3A2 /* MockUtils.framework */; };
 		498DF593219F7451009F1B3F /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498DF592219F7451009F1B3F /* NetworkMonitor.swift */; };
 		498DF595219F748D009F1B3F /* AuthMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498DF594219F748D009F1B3F /* AuthMonitor.swift */; };
+		4993C1AA23882EBD0070FA81 /* AppleCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4993C1A923882EBD0070FA81 /* AppleCredential.swift */; };
+		4993C1AC23882EC90070FA81 /* AppleAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4993C1AB23882EC90070FA81 /* AppleAuthProvider.swift */; };
 		4999DEDA22142A240081D742 /* StitchServiceBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4999DED922142A240081D742 /* StitchServiceBinder.swift */; };
 		4999DEDC22142CA60081D742 /* WeakReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4999DEDB22142CA60081D742 /* WeakReference.swift */; };
 		4999DEDE22142FC80081D742 /* AuthRebindEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4999DEDD22142FC80081D742 /* AuthRebindEvent.swift */; };
@@ -245,6 +247,8 @@
 		498062F72185C53A00E2A3A2 /* MockUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MockUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		498DF592219F7451009F1B3F /* NetworkMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		498DF594219F748D009F1B3F /* AuthMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthMonitor.swift; sourceTree = "<group>"; };
+		4993C1A923882EBD0070FA81 /* AppleCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleCredential.swift; sourceTree = "<group>"; };
+		4993C1AB23882EC90070FA81 /* AppleAuthProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthProvider.swift; sourceTree = "<group>"; };
 		4999DED922142A240081D742 /* StitchServiceBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StitchServiceBinder.swift; sourceTree = "<group>"; };
 		4999DEDB22142CA60081D742 /* WeakReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakReference.swift; sourceTree = "<group>"; };
 		4999DEDD22142FC80081D742 /* AuthRebindEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRebindEvent.swift; sourceTree = "<group>"; };
@@ -423,6 +427,7 @@
 		498062022185B6A100E2A3A2 /* Providers */ = {
 			isa = PBXGroup;
 			children = (
+				4993C1A823882EAB0070FA81 /* Apple */,
 				4922E3062371DAE500BA8D40 /* Function */,
 				498062032185B6A100E2A3A2 /* Anonymous */,
 				498062062185B6A100E2A3A2 /* Google */,
@@ -770,6 +775,15 @@
 			path = Internal;
 			sourceTree = "<group>";
 		};
+		4993C1A823882EAB0070FA81 /* Apple */ = {
+			isa = PBXGroup;
+			children = (
+				4993C1A923882EBD0070FA81 /* AppleCredential.swift */,
+				4993C1AB23882EC90070FA81 /* AppleAuthProvider.swift */,
+			);
+			path = Apple;
+			sourceTree = "<group>";
+		};
 		CC08727757358FF0F59F3D80 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -1042,10 +1056,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4993C1AA23882EBD0070FA81 /* AppleCredential.swift in Sources */,
 				1E524A552202418D009D818D /* CoreStitchAuth+AuthStorage.swift in Sources */,
 				4980627F2185B6BC00E2A3A2 /* StitchAppClientConfiguration.swift in Sources */,
 				498062802185B6BC00E2A3A2 /* StitchAppClientInfo.swift in Sources */,
 				498062812185B6BC00E2A3A2 /* ProviderCapabilities.swift in Sources */,
+				4993C1AC23882EC90070FA81 /* AppleAuthProvider.swift in Sources */,
 				498062822185B6BC00E2A3A2 /* StitchProviderType.swift in Sources */,
 				498062832185B6BC00E2A3A2 /* AnonymousCredential.swift in Sources */,
 				491A934F21B3248500F60F59 /* FoundationHTTPSSEStream.swift in Sources */,

--- a/Darwin/StitchCore/StitchCore.xcodeproj/project.pbxproj
+++ b/Darwin/StitchCore/StitchCore.xcodeproj/project.pbxproj
@@ -637,7 +637,6 @@
 				"${BUILT_PRODUCTS_DIR}/BlueRSA/CryptorRSA.framework",
 				"${BUILT_PRODUCTS_DIR}/KituraContracts/KituraContracts.framework",
 				"${BUILT_PRODUCTS_DIR}/LoggerAPI/LoggerAPI.framework",
-				"${BUILT_PRODUCTS_DIR}/Logging/Logging.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftJWT/SwiftJWT.framework",
 				"${BUILT_PRODUCTS_DIR}/Swifter/Swifter.framework",
 			);
@@ -653,7 +652,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CryptorRSA.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KituraContracts.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/LoggerAPI.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Logging.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftJWT.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Swifter.framework",
 			);

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -57,7 +57,7 @@ DEPENDENCIES:
   - Toast-Swift (= 4.0.0)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - BEMCheckBox
     - BlueCryptor
     - BlueECC
@@ -105,4 +105,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: ed787729049ae54d66114450249788d217c334c2
 
-COCOAPODS: 1.7.3
+COCOAPODS: 1.8.4


### PR DESCRIPTION
- Add `AppleCredential` and `AppleAuthProvider` to `Auth` group
- Add apple as a `ProviderConfig` for Stitch Admin SDK

Note: Automated testing would be massive time sink (and likely incredibly brittle). I have tested this using Apple's example Apple Sign-in application. It works fine.